### PR TITLE
Add Jupyter VS Code extension to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,8 @@
                 "shengchen.vscode-checkstyle",
                 "GitHub.vscode-github-actions",
                 "GitHub.copilot-chat",
-                "ms-python.python"
+                "ms-python.python",
+                "ms-toolsai.jupyter"
             ],
             "settings": {
                 "sonarlint.ls.javaHome": "/usr/local/sdkman/candidates/java/17.0.16-ms"


### PR DESCRIPTION
## Summary
- add the Jupyter VS Code extension to the devcontainer so notebook editing works out of the box

## Testing
- not run (tooling-only change)
