### PR TITLE
Add PySpark bridge library (Fixes #38)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION=21
+ARG JAVA_VERSION=11
 FROM mcr.microsoft.com/devcontainers/java:1-${JAVA_VERSION}-bookworm
 
 # Check for Zscaler certificates and install if found using external script
@@ -25,7 +25,7 @@ ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
 USER vscode
 
-COPY lib/python/opentoken/dev-requirements.txt /tmp/dev-requirements.txt
-COPY lib/python/opentoken/requirements.txt /tmp/requirements.txt
+COPY lib/python/dev-requirements.txt /tmp/dev-requirements.txt
+COPY lib/python/requirements.txt /tmp/requirements.txt
 
 RUN pip install -r /tmp/dev-requirements.txt --break-system-packages

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
         "context": "..",
         "dockerfile": "Dockerfile",
         "args": {
-            "JAVA_VERSION": "21"
+            "JAVA_VERSION": "11"
         }
     },
     "features": {
@@ -14,7 +14,8 @@
             "configureZshAsDefaultShell": true
         },
         "ghcr.io/devcontainers/features/java:1": {
-            "version": "21.0.9",
+            "version": "11.0.28",
+            "additionalVersions": "17.0.16",
             "installMaven": "true",
             "mavenVersion": "3.8.8",
             "installGradle": "false"
@@ -40,15 +41,21 @@
                 "shengchen.vscode-checkstyle",
                 "GitHub.vscode-github-actions",
                 "GitHub.copilot-chat",
-                "ms-python.python"
+                "ms-python.python",
+                "ms-toolsai.jupyter"
             ],
             "settings": {
-                "sonarlint.ls.javaHome": "/usr/local/sdkman/candidates/java/21.0.9-ms"
+                "sonarlint.ls.javaHome": "/usr/local/sdkman/candidates/java/17.0.16-ms"
             }
         }
     },
     "mounts": [],
-    "containerEnv": {},
-    "postCreateCommand": {},
+    "remoteEnv": {
+        "PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/.venv/bin",
+        "VIRTUAL_ENV": "${containerWorkspaceFolder}/.venv"
+    },
+    "postCreateCommand": {
+        "setup-python-env": ".devcontainer/scripts/setup-python-env.sh"
+    },
     "postStartCommand": {}
 }

--- a/.devcontainer/scripts/setup-python-env.sh
+++ b/.devcontainer/scripts/setup-python-env.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Setup Python virtual environment and install packages
+
+set -e
+
+echo "Setting up Python virtual environment..."
+
+# Get the workspace folder (use PWD if not set)
+WORKSPACE_DIR="${containerWorkspaceFolder:-$(pwd)}"
+
+# Create virtual environment in the workspace
+python3 -m venv "${WORKSPACE_DIR}/.venv"
+
+# Activate virtual environment
+source "${WORKSPACE_DIR}/.venv/bin/activate"
+
+# Upgrade pip
+python -m pip install --upgrade pip
+
+# Install ipykernel for Jupyter support
+pip install ipykernel
+
+# Install opentoken core package
+echo "Installing opentoken core package..."
+cd "${WORKSPACE_DIR}/lib/python"
+pip install -e .
+
+# Install opentoken-pyspark package
+echo "Installing opentoken-pyspark package..."
+cd "${WORKSPACE_DIR}/lib/python/opentoken-pyspark"
+pip install -r requirements.txt
+pip install -e .
+
+# Register the kernel with Jupyter
+python -m ipykernel install --user --name=opentoken --display-name="Python (OpenToken)"
+
+echo "Python environment setup complete!"
+echo "Virtual environment location: ${WORKSPACE_DIR}/.venv"
+echo "To activate: source ${WORKSPACE_DIR}/.venv/bin/activate"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,83 @@
+name: Python Package Publish
+
+on:
+  release:
+    types: [created, published, released]
+
+jobs:
+  publish-opentoken:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+    
+    - name: Build opentoken package
+      run: |
+        cd lib/python
+        python -m build
+    
+    - name: Publish opentoken to GitHub Packages
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
+      run: |
+        cd lib/python
+        # For GitHub Packages, use this instead:
+        # python -m twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
+        echo "Package built successfully. Configure PyPI token to publish."
+        ls -la dist/
+
+  publish-opentoken-pyspark:
+    runs-on: ubuntu-latest
+    needs: publish-opentoken
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+    
+    - name: Install opentoken core (required for pyspark package)
+      run: |
+        pip install -e lib/python/
+    
+    - name: Build opentoken-pyspark package
+      run: |
+        cd lib/python/opentoken-pyspark
+        python -m build
+    
+    - name: Publish opentoken-pyspark to GitHub Packages
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
+      run: |
+        cd lib/python/opentoken-pyspark
+        # For GitHub Packages, use this instead:
+        # python -m twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
+        echo "Package built successfully. Configure PyPI token to publish."
+        ls -la dist/

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -94,7 +94,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        python-version: ["3.10", 3.11]
+        python-version: ["3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -5,11 +5,13 @@ on:
     branches: [ main, develop ]
     paths:
       - 'lib/python/opentoken/**'
+      - 'lib/python/opentoken-pyspark/**'
       - '.github/workflows/python-test.yml'
   pull_request:
     branches: [ main, develop ]
     paths:
       - 'lib/python/opentoken/**'
+      - 'lib/python/opentoken-pyspark/**'
       - '.github/workflows/python-test.yml'
 
 jobs:
@@ -35,11 +37,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        if [ -f lib/python/opentoken/requirements.txt ]; then
-          pip install -r lib/python/opentoken/requirements.txt
+        if [ -f lib/python/requirements.txt ]; then
+          pip install -r lib/python/requirements.txt
         fi
         pip install pytest pytest-cov flake8
-        pip install -e lib/python/opentoken/
+        pip install -e lib/python/
     
     - name: Lint with flake8
       run: |
@@ -54,12 +56,12 @@ jobs:
 
     - name: Run main.py
       run: |
-        cd lib/python/opentoken
-        PYTHONPATH=src/main python3 src/main/opentoken/main.py -i ../../../resources/sample.csv -t csv -o target/output.csv -h "HashingKey"  -e "Secret-Encryption-Key-Goes-Here."
+        cd lib/python
+        PYTHONPATH=opentoken/src/main python3 opentoken/src/main/opentoken/main.py -i ../../resources/sample.csv -t csv -o target/output.csv -h "HashingKey"  -e "Secret-Encryption-Key-Goes-Here."
 
     - name: Validate Output Files Exist
       run: |
-        cd lib/python/opentoken
+        cd lib/python
         # Check if output files were created
         if [ ! -f "target/output.csv" ]; then
           echo "Error: output.csv not created"
@@ -75,7 +77,7 @@ jobs:
 
     - name: Validate Output Content
       run: |
-        cd lib/python/opentoken
+        cd lib/python
         # Check if output CSV has content (more than just headers)
         line_count=$(wc -l < target/output.csv)
         if [ "$line_count" -le 1 ]; then
@@ -83,3 +85,52 @@ jobs:
           exit 1
         fi
         echo "Output CSV contains $line_count lines"
+
+  test-pyspark:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      packages: write
+    strategy:
+      matrix:
+        python-version: ["3.10", 3.11]
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    
+    - name: Install Java (required by PySpark)
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+    
+    - name: Install opentoken core library
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e lib/python/
+    
+    - name: Install pyspark dependencies
+      run: |
+        if [ -f lib/python/opentoken-pyspark/requirements.txt ]; then
+          pip install -r lib/python/opentoken-pyspark/requirements.txt
+        fi
+        pip install pytest flake8
+        pip install -e lib/python/opentoken-pyspark/
+    
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 lib/python/opentoken-pyspark/src --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings
+        flake8 lib/python/opentoken-pyspark/src --count --exit-zero --statistics
+    
+    - name: Test with pytest
+      run: |
+        PYTHONPATH=lib/python/opentoken/src/main:lib/python/opentoken-pyspark/src/main pytest lib/python/opentoken-pyspark/src/test

--- a/lib/python/opentoken-pyspark/.flake8
+++ b/lib/python/opentoken-pyspark/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+exclude = .git,__pycache__,.venv,venv,build,dist

--- a/lib/python/opentoken-pyspark/IMPLEMENTATION_NOTES.md
+++ b/lib/python/opentoken-pyspark/IMPLEMENTATION_NOTES.md
@@ -1,0 +1,243 @@
+# OpenToken PySpark Bridge - Implementation Notes
+
+## Overview
+
+This document provides implementation details for the OpenToken PySpark bridge library added to the OpenToken project.
+
+## What Was Implemented
+
+### 1. Package Structure (`lib/python-pyspark/`)
+
+A complete Python package was created with the following structure:
+
+```
+lib/python-pyspark/
+├── setup.py                    # Package configuration
+├── requirements.txt            # Production dependencies
+├── dev-requirements.txt        # Development dependencies
+├── pyproject.toml             # pytest configuration
+├── .flake8                    # Code style configuration
+├── MANIFEST.in                # Package manifest
+├── README.md                  # Package documentation
+├── INSTALL.md                 # Detailed installation guide
+├── IMPLEMENTATION_NOTES.md    # This file
+├── src/
+│   ├── main/
+│   │   └── opentoken_pyspark/
+│   │       ├── __init__.py           # Package initialization
+│   │       └── token_processor.py    # Main implementation
+│   └── test/
+│       └── opentoken_pyspark/
+│           ├── __init__.py
+│           └── token_processor_test.py  # Comprehensive tests
+├── examples/
+│   └── simple_example.py      # Runnable example script
+└── notebooks/
+    └── OpenToken_PySpark_Example.ipynb  # Interactive tutorial
+```
+
+### 2. Core Implementation (`token_processor.py`)
+
+The `OpenTokenProcessor` class provides the main functionality:
+
+#### Key Features:
+- **Accepts PySpark DataFrames**: Works seamlessly with distributed data
+- **Pandas UDF Implementation**: Uses pandas UDFs for efficient batch processing
+- **Column Name Flexibility**: Supports multiple column name variants (e.g., FirstName/GivenName)
+- **Secret Management**: Validates and uses HMAC-SHA256 and AES-256 secrets
+- **Error Handling**: Comprehensive validation and error messages
+
+#### Architecture:
+1. Input DataFrame is validated for required columns
+2. Column names are mapped to standard attributes
+3. Pandas UDF processes batches of records in parallel
+4. For each record batch:
+   - Token transformers are initialized with secrets
+   - TokenGenerator creates tokens using OpenToken core library
+   - Results are collected and returned
+5. Output DataFrame contains: RecordId, RuleId, Token
+
+### 3. Test Suite (`token_processor_test.py`)
+
+Comprehensive tests covering:
+- Initialization with valid/invalid secrets
+- DataFrame processing with various column names
+- Error handling for missing columns
+- Token consistency and determinism
+- Different secrets producing different tokens
+- Empty DataFrames
+- Column mapping functionality
+
+All tests use pytest and PySpark's local testing mode.
+
+### 4. Documentation
+
+#### README.md
+- Feature overview
+- Quick start guide
+- Input/output format specifications
+- Performance considerations
+- Security notes
+
+#### INSTALL.md
+- Step-by-step installation instructions
+- Prerequisites
+- Troubleshooting guide
+- Docker alternative
+
+#### Jupyter Notebook
+- Interactive tutorial with examples
+- Data loading from CSV
+- Token generation
+- Result analysis and visualization
+- Alternative column name examples
+
+#### Simple Example Script
+- Standalone Python script
+- Demonstrates basic usage
+- Can be run directly for quick testing
+
+### 5. Version Management
+
+Updated version to 1.11.0 across all files:
+- `.bumpversion.cfg` - Added python-pyspark entries
+- `lib/java/pom.xml`
+- `lib/java/src/main/java/com/truveta/opentoken/Metadata.java`
+- `lib/python/setup.py`
+- `lib/python/src/main/opentoken/__init__.py`
+- `lib/python/src/main/opentoken/metadata.py`
+- `lib/python-pyspark/setup.py`
+- `lib/python-pyspark/src/main/opentoken_pyspark/__init__.py`
+- `Dockerfile`
+
+### 6. Main README Updates
+
+Added sections:
+- PySpark quick start guide
+- Updated project structure diagram
+- Links to PySpark bridge documentation
+
+### 7. .gitignore Updates
+
+Added exclusions for:
+- `.ipynb_checkpoints/`
+- `spark-warehouse/`
+- `metastore_db/`
+- `derby.log`
+
+## Technical Design Decisions
+
+### 1. Pandas UDF Choice
+**Decision**: Use Pandas UDFs instead of Row-based UDFs
+**Rationale**: 
+- Better performance with vectorized operations
+- More efficient serialization/deserialization
+- Natural integration with OpenToken's Python API
+
+### 2. Batch Processing
+**Decision**: Process records in batches within each partition
+**Rationale**:
+- Reduces overhead of token generator initialization
+- Balances memory usage with performance
+- Leverages PySpark's natural partitioning
+
+### 3. Column Name Flexibility
+**Decision**: Support multiple column name variants
+**Rationale**:
+- Improves usability with existing datasets
+- Matches OpenToken core library's approach
+- Reduces need for data preprocessing
+
+### 4. Secrets in UDF
+**Decision**: Pass secrets as closure variables to UDF
+**Rationale**:
+- Secrets are broadcast to workers efficiently
+- Transformer initialization happens once per batch
+- Maintains security while enabling distributed processing
+
+### 5. Separate Package
+**Decision**: Create a separate package instead of integrating into core
+**Rationale**:
+- Optional dependency (PySpark is large and not always needed)
+- Clear separation of concerns
+- Easier to test and maintain independently
+- Follows the project's structure pattern
+
+## Security Considerations
+
+1. **Secret Handling**: Secrets are serialized to worker nodes - ensure secure cluster configuration
+2. **Token Security**: Uses same cryptographic approach as core library
+3. **No Vulnerabilities**: Passed CodeQL security scan with zero issues
+4. **Input Validation**: Comprehensive validation before processing
+
+## Performance Characteristics
+
+- **Partitioning**: Inherits PySpark's natural partitioning
+- **Memory**: Memory-efficient batch processing
+- **Scalability**: Linear scaling with cluster size
+- **Optimization**: Can tune `spark.sql.shuffle.partitions` for workload
+
+## Testing Approach
+
+Tests were designed to be:
+1. **Independent**: Each test runs in isolation
+2. **Fast**: Use small datasets and local Spark mode
+3. **Comprehensive**: Cover happy paths and error cases
+4. **Maintainable**: Clear test names and structure
+
+## Known Limitations
+
+1. **Network Required**: PySpark installation requires internet connectivity
+2. **Java Dependency**: Requires Java 8+ for PySpark
+3. **Local Testing**: Full distributed testing requires a Spark cluster
+4. **Memory**: Large DataFrames may require executor memory tuning
+
+## Future Enhancements
+
+Potential improvements for future versions:
+
+1. **Caching**: Cache token transformers across batches
+2. **Partitioning Strategy**: Optimize partition size for token generation
+3. **Streaming**: Add support for Spark Structured Streaming
+4. **Broadcast Variables**: Use broadcast variables for secrets
+5. **Metrics**: Add detailed performance metrics
+6. **Integration Tests**: Add tests against real Spark clusters
+
+## Dependencies
+
+### Required
+- `pyspark>=3.0.0`: Apache Spark for distributed computing
+- `opentoken`: Core OpenToken library (local install)
+
+### Development
+- `pytest`: Testing framework
+- `jupyter`: Interactive notebooks
+- `notebook`: Jupyter notebook interface
+- `ipykernel`: Python kernel for Jupyter
+- `flake8`: Code linting
+
+## Compliance
+
+- **Code Style**: Passes flake8 with project configuration
+- **Security**: Passes CodeQL security scan
+- **Tests**: Comprehensive test coverage
+- **Documentation**: Complete documentation package
+- **Versioning**: Follows project's bump2version pattern
+
+## Integration Points
+
+### With Core Library
+- Uses `TokenGenerator` for token creation
+- Imports all attribute classes
+- Uses `TokenDefinition` for rule definitions
+- Uses `TokenTransformer` implementations
+
+### With PySpark
+- Integrates with DataFrame API
+- Uses Pandas UDFs for performance
+- Leverages partitioning for parallelism
+- Follows PySpark conventions
+
+## Conclusion
+
+The OpenToken PySpark bridge successfully extends OpenToken's capabilities to distributed computing environments, enabling large-scale privacy-preserving token generation while maintaining the security and correctness guarantees of the core library.

--- a/lib/python/opentoken-pyspark/INSTALL.md
+++ b/lib/python/opentoken-pyspark/INSTALL.md
@@ -1,0 +1,166 @@
+# OpenToken PySpark Installation Guide
+
+This guide walks you through installing and setting up the OpenToken PySpark bridge.
+
+## Prerequisites
+
+- Python 3.10 or higher
+- pip package manager
+- Java 8 or higher (required by PySpark)
+
+## Installation Steps
+
+### 1. Install OpenToken Core Library
+
+First, install the core OpenToken library:
+
+```bash
+cd lib/python
+pip install -e .
+```
+
+Verify the installation:
+
+```bash
+python -c "import opentoken; print(f'OpenToken version: {opentoken.__version__}')"
+```
+
+### 2. Install PySpark
+
+Install Apache PySpark:
+
+```bash
+pip install pyspark>=3.0.0
+```
+
+Verify PySpark installation:
+
+```bash
+python -c "import pyspark; print(f'PySpark version: {pyspark.__version__}')"
+```
+
+### 3. Install OpenToken PySpark Bridge
+
+Install the PySpark bridge:
+
+```bash
+cd ../python-pyspark
+pip install -e .
+```
+
+Verify the installation:
+
+```bash
+python -c "import opentoken_pyspark; print(f'OpenToken PySpark version: {opentoken_pyspark.__version__}')"
+```
+
+### 4. (Optional) Install Development Dependencies
+
+For development, testing, and Jupyter notebook support:
+
+```bash
+cd lib/python-pyspark
+pip install -e ".[dev]"
+```
+
+This installs additional packages:
+- pytest (for running tests)
+- jupyter (for running notebooks)
+- notebook (Jupyter Notebook interface)
+- ipykernel (Python kernel for Jupyter)
+- flake8 (code linting)
+
+## Verification
+
+Run a simple test to verify everything is working:
+
+```bash
+cd lib/python-pyspark
+python examples/simple_example.py
+```
+
+You should see output showing token generation for sample records.
+
+## Running Tests
+
+To run the test suite:
+
+```bash
+cd lib/python-pyspark
+pytest
+```
+
+## Using Jupyter Notebooks
+
+To explore the example notebook:
+
+```bash
+cd lib/python-pyspark/notebooks
+jupyter notebook OpenToken_PySpark_Example.ipynb
+```
+
+## Troubleshooting
+
+### Java Not Found
+
+If you get an error about Java not being found:
+
+1. Install Java 8 or higher
+2. Set the `JAVA_HOME` environment variable:
+   ```bash
+   export JAVA_HOME=/path/to/java
+   ```
+
+### PySpark Import Errors
+
+If you encounter import errors with PySpark:
+
+1. Ensure you have a compatible Python version (3.10+)
+2. Try reinstalling PySpark:
+   ```bash
+   pip uninstall pyspark
+   pip install pyspark>=3.0.0
+   ```
+
+### Memory Issues
+
+For large datasets, you may need to configure Spark memory:
+
+```python
+spark = SparkSession.builder \
+    .appName("OpenToken") \
+    .config("spark.executor.memory", "4g") \
+    .config("spark.driver.memory", "4g") \
+    .getOrCreate()
+```
+
+## Docker Installation (Alternative)
+
+If you prefer using Docker:
+
+```bash
+# Build the OpenToken Docker image
+cd /home/runner/work/OpenToken/OpenToken
+docker build -t opentoken:latest .
+
+# Run with PySpark
+docker run -it opentoken:latest bash
+# Then inside the container:
+cd lib/python-pyspark
+pip install pyspark
+python examples/simple_example.py
+```
+
+## Next Steps
+
+- Read the [README](README.md) for usage examples
+- Explore the [Jupyter notebook](notebooks/OpenToken_PySpark_Example.ipynb)
+- Check the [main documentation](../../README.md)
+
+## Getting Help
+
+If you encounter issues:
+
+1. Check the [main OpenToken documentation](../../README.md)
+2. Review the [development guide](../../docs/dev-guide-development.md)
+3. Open an issue on GitHub with details about your environment and error

--- a/lib/python/opentoken-pyspark/MANIFEST.in
+++ b/lib/python/opentoken-pyspark/MANIFEST.in
@@ -1,0 +1,10 @@
+include README.md
+include INSTALL.md
+include requirements.txt
+include dev-requirements.txt
+include pyproject.toml
+include .flake8
+recursive-include notebooks *.ipynb
+recursive-include examples *.py
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/lib/python/opentoken-pyspark/README.md
+++ b/lib/python/opentoken-pyspark/README.md
@@ -1,0 +1,254 @@
+# OpenToken PySpark Bridge
+
+A PySpark integration for the OpenToken library, enabling distributed privacy-preserving token generation for large-scale person matching workflows.
+
+## Overview
+
+The OpenToken PySpark Bridge provides a seamless interface between PySpark DataFrames and the OpenToken library, allowing you to generate cryptographically secure tokens for person matching in a distributed computing environment.
+
+## Features
+
+- **Distributed Processing**: Leverage PySpark's distributed computing capabilities for large datasets
+- **Simple API**: Easy-to-use interface that accepts PySpark DataFrames
+- **Compatible**: Works with standard OpenToken secrets for consistent token generation
+- **Flexible Column Names**: Supports multiple column name variants (e.g., FirstName/GivenName)
+- **Jupyter Ready**: Includes example notebooks for interactive exploration
+
+## Installation
+
+### Quick Install
+
+```bash
+# First, install the OpenToken core library
+cd lib/python
+pip install -e .
+
+# Then install the PySpark bridge
+cd ../python-pyspark
+pip install -e .
+```
+
+For detailed installation instructions, troubleshooting, and alternative installation methods, see [INSTALL.md](INSTALL.md).
+
+### Prerequisites
+
+- Python 3.10 or higher
+- PySpark 3.0.0 or higher
+- OpenToken core library
+- Java 8 or higher (required by PySpark)
+
+## Quick Start
+
+```python
+from pyspark.sql import SparkSession
+from opentoken_pyspark import OpenTokenProcessor
+
+# Create Spark session
+spark = SparkSession.builder \
+    .appName("OpenTokenExample") \
+    .master("local[*]") \
+    .getOrCreate()
+
+# Load your data
+df = spark.read.csv("data.csv", header=True)
+
+# Initialize processor with your secrets
+processor = OpenTokenProcessor(
+    hashing_secret="your-hashing-secret",
+    encryption_key="your-encryption-key"
+)
+
+# Generate tokens
+tokens_df = processor.process_dataframe(df)
+
+# View results
+tokens_df.show()
+```
+
+## Input DataFrame Requirements
+
+Your input DataFrame must contain the following columns (alternative names are supported):
+
+| Standard Name | Alternative Names | Description |
+|--------------|-------------------|-------------|
+| RecordId | Id | Unique identifier (optional - auto-generated if not provided) |
+| FirstName | GivenName | Person's first name |
+| LastName | Surname | Person's last name |
+| BirthDate | DateOfBirth | Date of birth in YYYY-MM-DD format |
+| Sex | Gender | Sex/Gender (Male, Female, M, F) |
+| PostalCode | ZipCode | US ZIP code or Canadian postal code |
+| SocialSecurityNumber | NationalIdentificationNumber | SSN or national ID number |
+
+## Output Format
+
+The output DataFrame contains:
+
+- **RecordId**: The original record identifier
+- **RuleId**: Token rule identifier (T1, T2, T3, T4, T5)
+- **Token**: The generated cryptographic token
+
+Each input record produces multiple output rows (one per token rule).
+
+## Using Custom Token Definitions
+
+You can define custom tokens using the `opentoken.notebook_helpers` module and pass them to the processor:
+
+```python
+from opentoken.notebook_helpers import TokenBuilder, CustomTokenDefinition
+from opentoken_pyspark import OpenTokenProcessor
+
+# Method 1: Using TokenBuilder
+custom_token = TokenBuilder("T6") \
+    .add("last_name", "T|U") \
+    .add("first_name", "T|U") \
+    .add("birth_date", "T|D") \
+    .add("postal_code", "T|S(0,3)") \
+    .add("sex", "T|U") \
+    .build()
+
+custom_definition = CustomTokenDefinition().add_token(custom_token)
+
+# Create processor with custom token definition
+processor = OpenTokenProcessor(
+    hashing_secret="your-hashing-secret",
+    encryption_key="your-encryption-key-32-chars!!",
+    token_definition=custom_definition  # Pass custom definition here
+)
+
+# Process DataFrame - will use T6 instead of default T1-T5
+tokens_df = processor.process_dataframe(df)
+```
+
+For more examples and interactive experimentation with custom tokens, see the [Custom Token Definition Guide](notebooks/Custom_Token_Definition_Guide.ipynb).
+
+## Example Notebooks
+
+See the included Jupyter notebooks for complete examples:
+
+**Basic Usage:**
+```bash
+cd notebooks
+jupyter notebook OpenToken_PySpark_Example.ipynb
+```
+
+**Custom Token Definitions:**
+```bash
+cd notebooks
+jupyter notebook Custom_Token_Definition_Guide.ipynb
+```
+
+## Dataset Overlap Analysis
+
+The `OpenTokenOverlapAnalyzer` class helps identify matching records between two tokenized datasets based on encrypted tokens.
+
+### Basic Usage
+
+```python
+from opentoken_pyspark import OpenTokenOverlapAnalyzer
+
+# Initialize with encryption key (same key used for token generation)
+analyzer = OpenTokenOverlapAnalyzer("encryption-key-32-characters!!")
+
+# Analyze overlap between two tokenized datasets
+# Match on tokens T1 and T2 (both must match)
+results = analyzer.analyze_overlap(
+    tokens_df1,
+    tokens_df2,
+    matching_rules=["T1", "T2"],
+    dataset1_name="Hospital_A",
+    dataset2_name="Hospital_B"
+)
+
+# Print summary
+analyzer.print_summary(results)
+
+# Access detailed results
+print(f"Total records in dataset 1: {results['total_records_dataset1']}")
+print(f"Matching records: {results['matching_records_dataset1']}")
+print(f"Overlap percentage: {results['overlap_percentage']:.2f}%")
+
+# Get DataFrame of matched record pairs
+matches_df = results['matches']
+matches_df.show()
+```
+
+### Compare with Multiple Rule Sets
+
+```python
+# Compare overlap using different matching criteria
+rule_sets = [
+    ["T1"],              # Match on T1 only
+    ["T1", "T2"],        # Match on T1 AND T2
+    ["T1", "T2", "T3"]   # Match on T1 AND T2 AND T3
+]
+
+results = analyzer.compare_with_multiple_rules(
+    tokens_df1, tokens_df2, rule_sets
+)
+
+# See how overlap changes with stricter rules
+for result in results:
+    print(f"Rules {result['matching_rules']}: "
+          f"{result['overlap_percentage']:.2f}% overlap")
+```
+
+### Use Cases
+
+- **Data Quality Assessment**: Identify duplicate records across datasets
+- **Patient Matching**: Find matching patients between healthcare systems
+- **Research Cohort Overlap**: Analyze overlap between research study populations
+- **Data Sharing Analysis**: Assess data overlap before establishing data sharing agreements
+
+### How It Works
+
+1. Both datasets must contain tokenized records (RecordId, RuleId, Token columns)
+2. Matching rules specify which token types must match (e.g., ["T1", "T2"])
+3. Records are considered matching only if ALL specified token types match
+4. The analyzer provides statistics and a DataFrame of matched record pairs
+5. Uses the same encryption key that was used to generate the tokens
+
+## Testing
+
+Run the test suite:
+
+```bash
+# From the python-pyspark directory
+pytest
+```
+
+## Performance Considerations
+
+- **Partitioning**: PySpark processes data in parallel across partitions. Adjust `spark.sql.shuffle.partitions` for your cluster size.
+- **Memory**: Token generation is memory-efficient but ensure adequate executor memory for your data volume.
+- **Secrets**: Secrets are serialized to worker nodes - ensure secure cluster configuration.
+
+## Architecture
+
+The PySpark bridge uses Pandas UDFs (User Defined Functions) to efficiently process batches of records:
+
+1. Data is partitioned across the Spark cluster
+2. Each partition is processed by a Pandas UDF
+3. Within each batch, the OpenToken library generates tokens
+4. Results are collected back into a PySpark DataFrame
+
+This architecture balances the benefits of distributed computing with the cryptographic requirements of token generation.
+
+## Security Notes
+
+- **Secrets Management**: Use secure secrets management systems in production (e.g., AWS Secrets Manager, Azure Key Vault)
+- **Network Security**: Ensure secure communication between Spark nodes
+- **Data Privacy**: Generated tokens are cryptographically secure and cannot be reversed to original values
+
+## Related Documentation
+
+- [OpenToken Core Library](../python/README.md)
+- [Main OpenToken Documentation](../../README.md)
+- [Development Guide](../../docs/dev-guide-development.md)
+
+## Contributing
+
+Contributions are welcome! Please see the main OpenToken contributing guidelines.
+
+## License
+
+Copyright (c) Truveta. All rights reserved.

--- a/lib/python/opentoken-pyspark/README.md
+++ b/lib/python/opentoken-pyspark/README.md
@@ -24,7 +24,7 @@ cd lib/python
 pip install -e .
 
 # Then install the PySpark bridge
-cd ../python-pyspark
+cd ../opentoken-pyspark
 pip install -e .
 ```
 

--- a/lib/python/opentoken-pyspark/dev-requirements.txt
+++ b/lib/python/opentoken-pyspark/dev-requirements.txt
@@ -1,0 +1,16 @@
+# Testing frameworks
+pytest
+
+# Code quality and linting
+flake8
+
+# Development tools
+bump2version
+
+# Jupyter support
+jupyter
+notebook
+ipykernel
+
+# Include production requirements
+-r requirements.txt

--- a/lib/python/opentoken-pyspark/examples/simple_example.py
+++ b/lib/python/opentoken-pyspark/examples/simple_example.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Simple example demonstrating OpenToken PySpark usage.
+
+This script shows how to use the OpenToken PySpark bridge to generate
+tokens from person data in a PySpark DataFrame.
+
+Prerequisites:
+    pip install -e ../python
+    pip install -e .
+
+Usage:
+    python simple_example.py
+"""
+
+from pyspark.sql import SparkSession
+from opentoken_pyspark import OpenTokenProcessor
+
+
+def main():
+    """Main function demonstrating token generation with PySpark."""
+
+    # Initialize Spark session
+    print("Initializing Spark session...")
+    spark = SparkSession.builder \
+        .appName("OpenTokenSimpleExample") \
+        .master("local[2]") \
+        .config("spark.sql.shuffle.partitions", "2") \
+        .getOrCreate()
+
+    print(f"Spark version: {spark.version}\n")
+
+    # Create sample data
+    print("Creating sample data...")
+    sample_data = [
+        {
+            "RecordId": "test-001",
+            "FirstName": "John",
+            "LastName": "Doe",
+            "PostalCode": "98004",
+            "Sex": "Male",
+            "BirthDate": "2000-01-01",
+            "SocialSecurityNumber": "123-45-6789"
+        },
+        {
+            "RecordId": "test-002",
+            "FirstName": "Jane",
+            "LastName": "Smith",
+            "PostalCode": "15635",
+            "Sex": "Female",
+            "BirthDate": "1995-06-15",
+            "SocialSecurityNumber": "987-65-4321"
+        }
+    ]
+
+    # Create DataFrame
+    df = spark.createDataFrame(sample_data)
+
+    print("Input DataFrame:")
+    df.show(truncate=False)
+
+    # Initialize OpenToken processor with secrets
+    print("\nInitializing OpenToken processor...")
+    processor = OpenTokenProcessor(
+        hashing_secret="HashingKey",
+        encryption_key="Secret-Encryption-Key-Goes-Here."
+    )
+
+    # Generate tokens
+    print("Generating tokens...")
+    tokens_df = processor.process_dataframe(df)
+
+    # Display results
+    print("\nGenerated Tokens:")
+    tokens_df.show(truncate=False)
+
+    # Show token count by rule
+    print("\nToken Count by RuleId:")
+    tokens_df.groupBy("RuleId").count().orderBy("RuleId").show()
+
+    # Show tokens for first record
+    first_record_id = sample_data[0]["RecordId"]
+    print(f"\nAll tokens for RecordId: {first_record_id}")
+    tokens_df.filter(tokens_df.RecordId == first_record_id).show(truncate=False)
+
+    # Stop Spark session
+    print("\nStopping Spark session...")
+    spark.stop()
+
+    print("Example completed successfully!")
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/python/opentoken-pyspark/notebooks/Custom_Token_Definition_Guide.ipynb
+++ b/lib/python/opentoken-pyspark/notebooks/Custom_Token_Definition_Guide.ipynb
@@ -1,0 +1,403 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Custom Token Definition Guide\n",
+    "\n",
+    "This notebook demonstrates how to create custom token definitions with minimal code using the OpenToken notebook helpers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "First, import the necessary modules:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from opentoken.notebook_helpers import (\n",
+    "    TokenBuilder,\n",
+    "    CustomTokenDefinition,\n",
+    "    create_token_generator,\n",
+    "    quick_token,\n",
+    "    list_attributes,\n",
+    "    expression_help\n",
+    ")\n",
+    "from opentoken.attributes.general.record_id_attribute import RecordIdAttribute\n",
+    "from opentoken.attributes.person.first_name_attribute import FirstNameAttribute\n",
+    "from opentoken.attributes.person.last_name_attribute import LastNameAttribute\n",
+    "from opentoken.attributes.person.birth_date_attribute import BirthDateAttribute\n",
+    "from opentoken.attributes.person.sex_attribute import SexAttribute\n",
+    "from opentoken.attributes.person.postal_code_attribute import PostalCodeAttribute"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## View Available Attributes\n",
+    "\n",
+    "Check what attributes are available:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "attrs = list_attributes()\n",
+    "print(\"Available attributes:\")\n",
+    "for name in attrs.keys():\n",
+    "    print(f\"  - {name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Expression Syntax Help\n",
+    "\n",
+    "Get help on expression syntax:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(expression_help())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Method 1: Quick Token (Simplest)\n",
+    "\n",
+    "Create a custom T6 token in one line with the rule:\n",
+    "`U(last-name)|U(first-name)|birth-date|postal-code-3|U(sex)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create T6 token generator in one call\n",
+    "generator = quick_token(\n",
+    "    \"T6\",\n",
+    "    [\n",
+    "        (\"last_name\", \"T|U\"),\n",
+    "        (\"first_name\", \"T|U\"),\n",
+    "        (\"birth_date\", \"T|D\"),\n",
+    "        (\"postal_code\", \"T|S(0,3)\"),\n",
+    "        (\"sex\", \"T|U\")\n",
+    "    ],\n",
+    "    \"my-hashing-secret\",\n",
+    "    \"my-32-character-encryption-key!\"\n",
+    ")\n",
+    "\n",
+    "# Test it with sample data\n",
+    "person_attrs = {\n",
+    "    RecordIdAttribute: \"1\",\n",
+    "    FirstNameAttribute: \"John\",\n",
+    "    LastNameAttribute: \"Doe\",\n",
+    "    BirthDateAttribute: \"1990-01-15\",\n",
+    "    SexAttribute: \"Male\",\n",
+    "    PostalCodeAttribute: \"98101\"\n",
+    "}\n",
+    "\n",
+    "result = generator.get_all_tokens(person_attrs)\n",
+    "print(f\"T6 Token: {result.tokens.get('T6')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Method 2: Token Builder (More Flexible)\n",
+    "\n",
+    "Use the fluent TokenBuilder API for more control:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a custom T6 token\n",
+    "t6_token = TokenBuilder(\"T6\") \\\n",
+    "    .add(\"last_name\", \"T|U\") \\\n",
+    "    .add(\"first_name\", \"T|U\") \\\n",
+    "    .add(\"birth_date\", \"T|D\") \\\n",
+    "    .add(\"postal_code\", \"T|S(0,3)\") \\\n",
+    "    .add(\"sex\", \"T|U\") \\\n",
+    "    .build()\n",
+    "\n",
+    "# Create a custom token definition\n",
+    "custom_definition = CustomTokenDefinition().add_token(t6_token)\n",
+    "\n",
+    "# Create token generator\n",
+    "generator = create_token_generator(\n",
+    "    \"my-hashing-secret\",\n",
+    "    \"my-32-character-encryption-key!\",\n",
+    "    custom_definition\n",
+    ")\n",
+    "\n",
+    "# Generate tokens\n",
+    "result = generator.get_all_tokens(person_attrs)\n",
+    "print(f\"T6 Token: {result.tokens.get('T6')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Method 3: Multiple Custom Tokens\n",
+    "\n",
+    "Define multiple tokens in one definition:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create T6 token: U(last-name)|U(first-name)|birth-date|postal-code-3|U(sex)\n",
+    "t6_token = TokenBuilder(\"T6\") \\\n",
+    "    .add(\"last_name\", \"T|U\") \\\n",
+    "    .add(\"first_name\", \"T|U\") \\\n",
+    "    .add(\"birth_date\", \"T|D\") \\\n",
+    "    .add(\"postal_code\", \"T|S(0,3)\") \\\n",
+    "    .add(\"sex\", \"T|U\") \\\n",
+    "    .build()\n",
+    "\n",
+    "# Create T7 token: U(last-name-3)|U(first-name-3)|birth-date\n",
+    "t7_token = TokenBuilder(\"T7\") \\\n",
+    "    .add(\"last_name\", \"T|S(0,3)|U\") \\\n",
+    "    .add(\"first_name\", \"T|S(0,3)|U\") \\\n",
+    "    .add(\"birth_date\", \"T|D\") \\\n",
+    "    .build()\n",
+    "\n",
+    "# Add both tokens to definition\n",
+    "custom_definition = CustomTokenDefinition() \\\n",
+    "    .add_token(t6_token) \\\n",
+    "    .add_token(t7_token)\n",
+    "\n",
+    "# Create generator\n",
+    "generator = create_token_generator(\n",
+    "    \"my-hashing-secret\",\n",
+    "    \"my-32-character-encryption-key!\",\n",
+    "    custom_definition\n",
+    ")\n",
+    "\n",
+    "# Generate both tokens\n",
+    "result = generator.get_all_tokens(person_attrs)\n",
+    "print(f\"T6 Token: {result.tokens.get('T6')}\")\n",
+    "print(f\"T7 Token: {result.tokens.get('T7')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using Custom Tokens with PySpark DataFrames\n",
+    "\n",
+    "The key is to pass your custom TokenDefinition to the OpenTokenProcessor:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "from opentoken_pyspark import OpenTokenProcessor\n",
+    "from opentoken.notebook_helpers import TokenBuilder, CustomTokenDefinition\n",
+    "\n",
+    "# Create Spark session\n",
+    "spark = SparkSession.builder.appName(\"CustomTokens\").getOrCreate()\n",
+    "\n",
+    "# Create sample DataFrame\n",
+    "data = [\n",
+    "    (\"1\", \"John\", \"Doe\", \"1990-01-15\", \"Male\", \"98101\"),\n",
+    "    (\"2\", \"Jane\", \"Smith\", \"1985-06-20\", \"Female\", \"94105\")\n",
+    "]\n",
+    "df = spark.createDataFrame(data, [\"RecordId\", \"FirstName\", \"LastName\", \"BirthDate\", \"Sex\", \"PostalCode\"])\n",
+    "\n",
+    "# Step 1: Define your custom T6 token\n",
+    "t6_token = TokenBuilder(\"T6\") \\\n",
+    "    .add(\"last_name\", \"T|U\") \\\n",
+    "    .add(\"first_name\", \"T|U\") \\\n",
+    "    .add(\"birth_date\", \"T|D\") \\\n",
+    "    .add(\"postal_code\", \"T|S(0,3)\") \\\n",
+    "    .add(\"sex\", \"T|U\") \\\n",
+    "    .build()\n",
+    "\n",
+    "# Step 2: Create custom token definition\n",
+    "custom_definition = CustomTokenDefinition().add_token(t6_token)\n",
+    "\n",
+    "# Step 3: Create processor with custom definition\n",
+    "processor = OpenTokenProcessor(\n",
+    "    hashing_secret=\"my-hashing-secret\",\n",
+    "    encryption_key=\"my-32-character-encryption-key!\",\n",
+    "    token_definition=custom_definition  # Pass custom definition here!\n",
+    ")\n",
+    "\n",
+    "# Step 4: Process DataFrame with custom tokens\n",
+    "tokens_df = processor.process_dataframe(df)\n",
+    "\n",
+    "# Show results - you'll see T6 tokens instead of T1-T5!\n",
+    "print(\"Custom T6 tokens generated:\")\n",
+    "tokens_df.show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Multiple Custom Tokens with PySpark\n",
+    "\n",
+    "You can also use multiple custom tokens:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define multiple custom tokens\n",
+    "t6_token = TokenBuilder(\"T6\") \\\n",
+    "    .add(\"last_name\", \"T|U\") \\\n",
+    "    .add(\"first_name\", \"T|U\") \\\n",
+    "    .add(\"birth_date\", \"T|D\") \\\n",
+    "    .add(\"postal_code\", \"T|S(0,3)\") \\\n",
+    "    .add(\"sex\", \"T|U\") \\\n",
+    "    .build()\n",
+    "\n",
+    "t7_token = TokenBuilder(\"T7\") \\\n",
+    "    .add(\"last_name\", \"T|S(0,3)|U\") \\\n",
+    "    .add(\"first_name\", \"T|S(0,3)|U\") \\\n",
+    "    .add(\"birth_date\", \"T|D\") \\\n",
+    "    .build()\n",
+    "\n",
+    "# Add both to definition\n",
+    "multi_definition = CustomTokenDefinition() \\\n",
+    "    .add_token(t6_token) \\\n",
+    "    .add_token(t7_token)\n",
+    "\n",
+    "# Create processor with multiple custom tokens\n",
+    "processor_multi = OpenTokenProcessor(\n",
+    "    hashing_secret=\"my-hashing-secret\",\n",
+    "    encryption_key=\"my-32-character-encryption-key!\",\n",
+    "    token_definition=multi_definition\n",
+    ")\n",
+    "\n",
+    "# Process - will generate both T6 and T7 tokens\n",
+    "multi_tokens_df = processor_multi.process_dataframe(df)\n",
+    "\n",
+    "print(\"Multiple custom tokens (T6 and T7):\")\n",
+    "multi_tokens_df.show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Experiment with Different Rules\n",
+    "\n",
+    "Try different combinations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Minimal token: just last name and first initial\n",
+    "minimal_token = TokenBuilder(\"MINIMAL\") \\\n",
+    "    .add(\"last_name\", \"T|U\") \\\n",
+    "    .add(\"first_name\", \"T|S(0,1)|U\") \\\n",
+    "    .build()\n",
+    "\n",
+    "# Full token: everything\n",
+    "full_token = TokenBuilder(\"FULL\") \\\n",
+    "    .add(\"last_name\", \"T|U\") \\\n",
+    "    .add(\"first_name\", \"T|U\") \\\n",
+    "    .add(\"birth_date\", \"T|D\") \\\n",
+    "    .add(\"sex\", \"T|U\") \\\n",
+    "    .add(\"postal_code\", \"T|S(0,5)\") \\\n",
+    "    .add(\"ssn\", \"T\") \\\n",
+    "    .build()\n",
+    "\n",
+    "# Create definition with both\n",
+    "definition = CustomTokenDefinition() \\\n",
+    "    .add_token(minimal_token) \\\n",
+    "    .add_token(full_token)\n",
+    "\n",
+    "generator = create_token_generator(\n",
+    "    \"my-hashing-secret\",\n",
+    "    \"my-32-character-encryption-key!\",\n",
+    "    definition\n",
+    ")\n",
+    "\n",
+    "result = generator.get_all_tokens(person_attrs)\n",
+    "print(f\"Minimal Token: {result.tokens.get('MINIMAL')}\")\n",
+    "print(f\"Full Token: {result.tokens.get('FULL')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "Three ways to create custom tokens:\n",
+    "\n",
+    "1. **`quick_token()`** - Fastest, one-liner approach for simple cases\n",
+    "2. **`TokenBuilder`** - Fluent API for readable, flexible definitions\n",
+    "3. **Manual classes** - Full control (as shown in previous examples)\n",
+    "\n",
+    "Choose the method that best fits your workflow!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (OpenToken)",
+   "language": "python",
+   "name": "opentoken"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/lib/python/opentoken-pyspark/notebooks/Dataset_Overlap_Analysis_Guide.ipynb
+++ b/lib/python/opentoken-pyspark/notebooks/Dataset_Overlap_Analysis_Guide.ipynb
@@ -1,0 +1,358 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dataset Overlap Analysis Guide\n",
+    "\n",
+    "This notebook demonstrates how to use the `OpenTokenOverlapAnalyzer` class to identify matching records between two tokenized datasets.\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "The OpenTokenOverlapAnalyzer helps you:\n",
+    "- Find matching records across two datasets based on encrypted tokens\n",
+    "- Define flexible matching rules (which token types must match)\n",
+    "- Compare overlap rates using different matching criteria\n",
+    "- Get detailed statistics and matched record pairs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "from opentoken_pyspark import OpenTokenProcessor, OpenTokenOverlapAnalyzer\n",
+    "\n",
+    "# Create Spark session\n",
+    "spark = SparkSession.builder \\\n",
+    "    .appName(\"OverlapAnalysisExample\") \\\n",
+    "    .master(\"local[*]\") \\\n",
+    "    .getOrCreate()\n",
+    "\n",
+    "# Set secrets (use the same secrets for both datasets!)\n",
+    "HASHING_SECRET = \"my-hashing-secret-key\"\n",
+    "ENCRYPTION_KEY = \"my-encryption-key-32-chars!!!\"  # Must be 32 characters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Sample Datasets\n",
+    "\n",
+    "Let's create two datasets representing patient records from different hospitals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hospital A data\n",
+    "hospital_a_data = [\n",
+    "    (\"A001\", \"John\", \"Doe\", \"1990-01-15\", \"Male\", \"98101\", \"123-45-6789\"),\n",
+    "    (\"A002\", \"Jane\", \"Smith\", \"1985-06-20\", \"Female\", \"94105\", \"987-65-4321\"),\n",
+    "    (\"A003\", \"Bob\", \"Johnson\", \"1978-03-10\", \"Male\", \"02134\", \"456-78-9123\"),\n",
+    "    (\"A004\", \"Alice\", \"Williams\", \"1992-11-05\", \"Female\", \"10001\", \"321-54-9876\"),\n",
+    "    (\"A005\", \"Charlie\", \"Brown\", \"1988-08-22\", \"Male\", \"60614\", \"789-12-3456\"),\n",
+    "]\n",
+    "\n",
+    "hospital_a_df = spark.createDataFrame(\n",
+    "    hospital_a_data,\n",
+    "    [\"RecordId\", \"FirstName\", \"LastName\", \"BirthDate\", \"Sex\", \"PostalCode\", \"SocialSecurityNumber\"]\n",
+    ")\n",
+    "\n",
+    "print(\"Hospital A Records:\")\n",
+    "hospital_a_df.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hospital B data (has some overlapping patients)\n",
+    "hospital_b_data = [\n",
+    "    (\"B101\", \"John\", \"Doe\", \"1990-01-15\", \"Male\", \"98101\", \"123-45-6789\"),     # Same as A001\n",
+    "    (\"B102\", \"Jane\", \"Smith\", \"1985-06-20\", \"Female\", \"94105\", \"987-65-4321\"),  # Same as A002\n",
+    "    (\"B103\", \"David\", \"Lee\", \"1995-04-18\", \"Male\", \"30303\", \"654-32-1098\"),     # Unique to B\n",
+    "    (\"B104\", \"Emma\", \"Davis\", \"1982-12-30\", \"Female\", \"90210\", \"234-56-7890\"),  # Unique to B\n",
+    "]\n",
+    "\n",
+    "hospital_b_df = spark.createDataFrame(\n",
+    "    hospital_b_data,\n",
+    "    [\"RecordId\", \"FirstName\", \"LastName\", \"BirthDate\", \"Sex\", \"PostalCode\", \"SocialSecurityNumber\"]\n",
+    ")\n",
+    "\n",
+    "print(\"Hospital B Records:\")\n",
+    "hospital_b_df.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate Tokens for Both Datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize token processor\n",
+    "processor = OpenTokenProcessor(HASHING_SECRET, ENCRYPTION_KEY)\n",
+    "\n",
+    "# Generate tokens for Hospital A\n",
+    "hospital_a_tokens = processor.process_dataframe(hospital_a_df)\n",
+    "print(\"Hospital A Tokens:\")\n",
+    "hospital_a_tokens.show(5, truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate tokens for Hospital B\n",
+    "hospital_b_tokens = processor.process_dataframe(hospital_b_df)\n",
+    "print(\"Hospital B Tokens:\")\n",
+    "hospital_b_tokens.show(5, truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analyze Dataset Overlap\n",
+    "\n",
+    "### Method 1: Single Rule Set\n",
+    "\n",
+    "Let's find matches requiring T1 and T2 tokens to match."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize overlap analyzer with the same encryption key\n",
+    "analyzer = OpenTokenOverlapAnalyzer(ENCRYPTION_KEY)\n",
+    "\n",
+    "# Analyze overlap with T1 and T2 matching rules\n",
+    "results = analyzer.analyze_overlap(\n",
+    "    hospital_a_tokens,\n",
+    "    hospital_b_tokens,\n",
+    "    matching_rules=[\"T1\", \"T2\"],\n",
+    "    dataset1_name=\"Hospital_A\",\n",
+    "    dataset2_name=\"Hospital_B\"\n",
+    ")\n",
+    "\n",
+    "# Print summary\n",
+    "analyzer.print_summary(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### View Matched Record Pairs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show matched record pairs\n",
+    "print(\"Matched Record Pairs:\")\n",
+    "results['matches'].show()\n",
+    "\n",
+    "# Expected: Should show A001<->B101 and A002<->B102"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Method 2: Compare Multiple Rule Sets\n",
+    "\n",
+    "Let's see how overlap changes with different matching criteria."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define different rule sets to compare\n",
+    "rule_sets = [\n",
+    "    [\"T1\"],              # Least strict: only T1 must match\n",
+    "    [\"T1\", \"T2\"],        # Medium: T1 AND T2 must match\n",
+    "    [\"T1\", \"T2\", \"T3\"],  # Strict: T1 AND T2 AND T3 must match\n",
+    "    [\"T1\", \"T2\", \"T3\", \"T4\"],  # Very strict: all 4 tokens must match\n",
+    "]\n",
+    "\n",
+    "# Run comparison\n",
+    "multi_results = analyzer.compare_with_multiple_rules(\n",
+    "    hospital_a_tokens,\n",
+    "    hospital_b_tokens,\n",
+    "    rule_sets,\n",
+    "    dataset1_name=\"Hospital_A\",\n",
+    "    dataset2_name=\"Hospital_B\"\n",
+    ")\n",
+    "\n",
+    "# Display comparison\n",
+    "print(\"\\nOverlap Comparison Across Different Matching Rules:\")\n",
+    "print(\"=\" * 70)\n",
+    "for result in multi_results:\n",
+    "    rules_str = \", \".join(result['matching_rules'])\n",
+    "    print(f\"Rules: {rules_str:20} | \"\n",
+    "          f\"Matches: {result['matching_records_dataset1']:2} | \"\n",
+    "          f\"Overlap: {result['overlap_percentage']:5.1f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Access Detailed Statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Access detailed statistics from any result\n",
+    "result = multi_results[1]  # T1 + T2 result\n",
+    "\n",
+    "print(f\"Dataset: {result['dataset1_name']}\")\n",
+    "print(f\"  Total records: {result['total_records_dataset1']}\")\n",
+    "print(f\"  Matching records: {result['matching_records_dataset1']}\")\n",
+    "print(f\"  Unique records: {result['unique_to_dataset1']}\")\n",
+    "print()\n",
+    "print(f\"Dataset: {result['dataset2_name']}\")\n",
+    "print(f\"  Total records: {result['total_records_dataset2']}\")\n",
+    "print(f\"  Matching records: {result['matching_records_dataset2']}\")\n",
+    "print(f\"  Unique records: {result['unique_to_dataset2']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Case: Analyzing Data Sharing Potential\n",
+    "\n",
+    "Let's say you want to assess whether two institutions should establish a data sharing agreement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Analyze with strict matching criteria\n",
+    "strict_results = analyzer.analyze_overlap(\n",
+    "    hospital_a_tokens,\n",
+    "    hospital_b_tokens,\n",
+    "    matching_rules=[\"T1\", \"T2\", \"T3\"],  # Require 3 token types to match\n",
+    "    dataset1_name=\"Hospital_A\",\n",
+    "    dataset2_name=\"Hospital_B\"\n",
+    ")\n",
+    "\n",
+    "# Decision logic\n",
+    "overlap_pct = strict_results['overlap_percentage']\n",
+    "unique_a = strict_results['unique_to_dataset1']\n",
+    "unique_b = strict_results['unique_to_dataset2']\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 70)\n",
+    "print(\"DATA SHARING ASSESSMENT\")\n",
+    "print(\"=\" * 70)\n",
+    "print(f\"Overlap: {overlap_pct:.1f}%\")\n",
+    "print(f\"Unique records in Hospital A: {unique_a}\")\n",
+    "print(f\"Unique records in Hospital B: {unique_b}\")\n",
+    "print()\n",
+    "\n",
+    "if overlap_pct < 10:\n",
+    "    print(\"✓ RECOMMENDATION: High potential for data sharing\")\n",
+    "    print(\"  Minimal overlap suggests complementary patient populations.\")\n",
+    "elif overlap_pct < 30:\n",
+    "    print(\"✓ RECOMMENDATION: Moderate potential for data sharing\")\n",
+    "    print(\"  Some overlap exists but substantial unique populations in each dataset.\")\n",
+    "else:\n",
+    "    print(\"⚠ RECOMMENDATION: Review data sharing need carefully\")\n",
+    "    print(\"  Significant overlap may reduce value of data sharing.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Stop Spark session\n",
+    "spark.stop()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Key Takeaways\n",
+    "\n",
+    "1. **Encryption Key**: Must be the same key used to generate tokens\n",
+    "2. **Matching Rules**: Define which token types must match (ALL must match, not just one)\n",
+    "3. **Multiple Criteria**: Use `compare_with_multiple_rules()` to see how overlap changes with stricter matching\n",
+    "4. **Privacy**: Analysis uses encrypted tokens - no PHI is exposed\n",
+    "5. **Results**: Get both statistics and detailed matched record pairs\n",
+    "\n",
+    "## Next Steps\n",
+    "\n",
+    "- Try with your own datasets\n",
+    "- Experiment with different token rule combinations\n",
+    "- Use custom token definitions (see Custom_Token_Definition_Guide.ipynb)\n",
+    "- Scale to larger datasets using your Spark cluster"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/lib/python/opentoken-pyspark/notebooks/OpenToken_PySpark_Example.ipynb
+++ b/lib/python/opentoken-pyspark/notebooks/OpenToken_PySpark_Example.ipynb
@@ -1,0 +1,345 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OpenToken PySpark Example\n",
+    "\n",
+    "This notebook demonstrates how to use the OpenToken PySpark bridge to generate privacy-preserving tokens from a PySpark DataFrame.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "1. Install the required packages:\n",
+    "   ```bash\n",
+    "   cd lib/python\n",
+    "   pip install -e .\n",
+    "   cd ../python-pyspark\n",
+    "   pip install -e .\n",
+    "   ```\n",
+    "\n",
+    "2. Ensure you have PySpark and Jupyter installed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import required libraries\n",
+    "from pyspark.sql import SparkSession\n",
+    "from opentoken_pyspark import OpenTokenProcessor\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a Spark session\n",
+    "spark = SparkSession.builder \\\n",
+    "    .appName(\"OpenTokenExample\") \\\n",
+    "    .master(\"local[*]\") \\\n",
+    "    .getOrCreate()\n",
+    "\n",
+    "print(f\"Spark version: {spark.version}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Sample Data\n",
+    "\n",
+    "We'll load the sample CSV data into a PySpark DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load sample data from CSV\n",
+    "sample_csv_path = \"../../../../resources/sample.csv\"\n",
+    "\n",
+    "df = spark.read.csv(\n",
+    "    sample_csv_path,\n",
+    "    header=True,\n",
+    "    inferSchema=True\n",
+    ")\n",
+    "\n",
+    "# Display the schema\n",
+    "print(\"Input DataFrame Schema:\")\n",
+    "df.printSchema()\n",
+    "\n",
+    "# Show first few rows\n",
+    "print(\"\\nFirst 5 rows:\")\n",
+    "df.show(5, truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize OpenToken Processor\n",
+    "\n",
+    "Create an instance of the OpenTokenProcessor with your hashing secret and encryption key.\n",
+    "\n",
+    "**Note:** The secrets used here are for demonstration purposes only. In production, use secure secrets management."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize the processor with secrets\n",
+    "processor = OpenTokenProcessor(\n",
+    "    hashing_secret=\"HashingKey\",\n",
+    "    encryption_key=\"Secret-Encryption-Key-Goes-Here.\"\n",
+    ")\n",
+    "\n",
+    "print(\"OpenToken Processor initialized successfully!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate Tokens\n",
+    "\n",
+    "Process the DataFrame to generate tokens for each person record."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate tokens\n",
+    "tokens_df = processor.process_dataframe(df)\n",
+    "\n",
+    "# Display the schema of the result\n",
+    "print(\"Output DataFrame Schema:\")\n",
+    "tokens_df.printSchema()\n",
+    "\n",
+    "# Count total tokens generated\n",
+    "total_tokens = tokens_df.count()\n",
+    "print(f\"\\nTotal tokens generated: {total_tokens}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect Results\n",
+    "\n",
+    "Let's look at the generated tokens for a specific record."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show tokens for the first record\n",
+    "first_record_id = df.select(\"RecordId\").first()[0]\n",
+    "print(f\"Tokens for RecordId: {first_record_id}\")\n",
+    "\n",
+    "tokens_df.filter(tokens_df.RecordId == first_record_id).show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analyze Token Distribution\n",
+    "\n",
+    "Check how many tokens were generated per rule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Count tokens by RuleId\n",
+    "print(\"Token count by RuleId:\")\n",
+    "tokens_df.groupBy(\"RuleId\").count().orderBy(\"RuleId\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert to Pandas for Visualization\n",
+    "\n",
+    "For smaller datasets, you can convert to Pandas for easier visualization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert a subset to Pandas for visualization\n",
+    "sample_tokens = tokens_df.limit(10).toPandas()\n",
+    "print(\"Sample tokens as Pandas DataFrame:\")\n",
+    "display(sample_tokens)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save Results\n",
+    "\n",
+    "Save the tokens to a Parquet file for further processing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save to Parquet\n",
+    "output_path = \"../output/tokens_output.parquet\"\n",
+    "\n",
+    "tokens_df.write.mode(\"overwrite\").parquet(output_path)\n",
+    "print(f\"Tokens saved to: {output_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example: Using Alternative Column Names\n",
+    "\n",
+    "OpenToken supports alternative column names for flexibility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a DataFrame with alternative column names\n",
+    "alt_data = [\n",
+    "    {\n",
+    "        \"Id\": \"custom-001\",\n",
+    "        \"GivenName\": \"Alice\",\n",
+    "        \"Surname\": \"Johnson\",\n",
+    "        \"ZipCode\": \"98052\",\n",
+    "        \"Gender\": \"Female\",\n",
+    "        \"DateOfBirth\": \"1990-05-15\",\n",
+    "        \"NationalIdentificationNumber\": \"234-56-7890\"\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "alt_df = spark.createDataFrame(alt_data)\n",
+    "\n",
+    "# Process with alternative column names\n",
+    "alt_tokens_df = processor.process_dataframe(alt_df)\n",
+    "\n",
+    "print(\"Tokens generated with alternative column names:\")\n",
+    "alt_tokens_df.show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Performance Considerations\n",
+    "\n",
+    "For large datasets, PySpark processes data in parallel across the cluster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check the number of partitions\n",
+    "print(f\"Number of partitions in input DataFrame: {df.rdd.getNumPartitions()}\")\n",
+    "print(f\"Number of partitions in output DataFrame: {tokens_df.rdd.getNumPartitions()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup\n",
+    "\n",
+    "Stop the Spark session when done."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Stop Spark session\n",
+    "# spark.stop()\n",
+    "print(\"Session complete. Uncomment the line above to stop Spark.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated:\n",
+    "\n",
+    "1. Loading person data into a PySpark DataFrame\n",
+    "2. Initializing the OpenToken processor with secrets\n",
+    "3. Generating privacy-preserving tokens for each record\n",
+    "4. Analyzing and visualizing the results\n",
+    "5. Saving tokens for further use\n",
+    "\n",
+    "The PySpark bridge enables distributed token generation for large-scale person matching workflows."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.11.2)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/lib/python/opentoken-pyspark/pyproject.toml
+++ b/lib/python/opentoken-pyspark/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.pytest.ini_options]
+testpaths = ["src/test"]
+python_files = ["*_test.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]

--- a/lib/python/opentoken-pyspark/requirements.txt
+++ b/lib/python/opentoken-pyspark/requirements.txt
@@ -1,0 +1,8 @@
+# PySpark for distributed processing
+pyspark==3.5.6
+
+# Cryptography for token decryption in overlap analysis
+pycryptodome>=3.18.0
+
+# OpenToken core library (local install required)
+# Install with: pip install -e ../opentoken

--- a/lib/python/opentoken-pyspark/setup.py
+++ b/lib/python/opentoken-pyspark/setup.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Setup script for OpenToken PySpark package."""
+
+from setuptools import setup, find_packages
+import os
+
+# Read the contents of the project README file.
+this_directory = os.path.abspath(os.path.dirname(__file__))
+root_readme = os.path.abspath(os.path.join(this_directory, "..", "..", "..", "README.md"))
+readme_path = root_readme if os.path.exists(root_readme) else os.path.join(this_directory, "README.md")
+try:
+    with open(readme_path, encoding="utf-8") as f:
+        long_description = f.read()
+except FileNotFoundError:
+    # Fallback to a short description if README is unavailable
+    long_description = "OpenToken PySpark bridge for distributed token generation."
+
+# Read requirements from requirements.txt
+with open(os.path.join(this_directory, "requirements.txt"), encoding="utf-8") as f:
+    requirements = [line.strip() for line in f if line.strip() and not line.startswith("#")]
+
+setup(
+    name="opentoken-pyspark",
+    version="1.11.0",
+    author="Truveta",
+    description="OpenToken PySpark bridge for distributed token generation",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/Truveta/OpenToken",
+    project_urls={
+        "Source": "https://github.com/Truveta/OpenToken",
+        "Documentation": "https://github.com/Truveta/OpenToken/blob/main/README.md",
+    },
+    package_dir={"": "src/main"},
+    packages=find_packages(where="src/main"),
+    python_requires=">=3.10",
+    install_requires=requirements,
+    extras_require={
+        "dev": [
+            "pytest",
+            "jupyter",
+            "notebook",
+            "ipykernel",
+        ],
+    },
+    entry_points={},
+)

--- a/lib/python/opentoken-pyspark/src/main/opentoken_pyspark/__init__.py
+++ b/lib/python/opentoken-pyspark/src/main/opentoken_pyspark/__init__.py
@@ -1,0 +1,12 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+
+OpenToken PySpark Bridge - Distributed token generation for PySpark DataFrames.
+"""
+
+__version__ = "1.11.0"
+
+from opentoken_pyspark.token_processor import OpenTokenProcessor
+from opentoken_pyspark.overlap_analyzer import OpenTokenOverlapAnalyzer
+
+__all__ = ["OpenTokenProcessor", "OpenTokenOverlapAnalyzer"]

--- a/lib/python/opentoken-pyspark/src/main/opentoken_pyspark/overlap_analyzer.py
+++ b/lib/python/opentoken-pyspark/src/main/opentoken_pyspark/overlap_analyzer.py
@@ -1,0 +1,263 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+
+Dataset overlap analyzer for comparing tokenized datasets.
+"""
+
+import logging
+from typing import List, Dict, Optional, Tuple
+from pyspark.sql import DataFrame
+from pyspark.sql.functions import col, lit, when, count, sum as spark_sum
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import unpad
+import base64
+
+
+logger = logging.getLogger(__name__)
+
+
+class OpenTokenOverlapAnalyzer:
+    """
+    Analyze overlap between two tokenized datasets based on matching rules.
+
+    This class helps identify records that match between two datasets using
+    encrypted tokens. It supports flexible matching rules based on specific
+    token types (T1-T5 or custom tokens).
+    """
+
+    def __init__(self, encryption_key: str):
+        """
+        Initialize the overlap analyzer with encryption key.
+
+        Args:
+            encryption_key: The same AES-256 encryption key used to encrypt tokens.
+                           Required to decrypt tokens for comparison.
+
+        Raises:
+            ValueError: If encryption key is empty or invalid length
+
+        Example:
+            >>> analyzer = OpenTokenOverlapAnalyzer("encryption-key-32-characters!!")
+        """
+        if not encryption_key or not encryption_key.strip():
+            raise ValueError("Encryption key cannot be empty")
+        if len(encryption_key.encode('utf-8')) != 32:
+            raise ValueError(
+                "Encryption key must be exactly 32 bytes (characters) for AES-256. "
+                f"Got {len(encryption_key.encode('utf-8'))} bytes"
+            )
+        self.encryption_key = encryption_key.encode('utf-8')
+
+    def _decrypt_token(self, encrypted_token: str) -> str:
+        """
+        Decrypt an encrypted token.
+
+        Args:
+            encrypted_token: Base64-encoded encrypted token
+
+        Returns:
+            Decrypted token string
+        """
+        try:
+            encrypted_data = base64.b64decode(encrypted_token)
+            iv = encrypted_data[:16]
+            ciphertext = encrypted_data[16:]
+
+            cipher = AES.new(self.encryption_key, AES.MODE_CBC, iv)
+            decrypted = unpad(cipher.decrypt(ciphertext), AES.block_size)
+            return decrypted.decode('utf-8')
+        except Exception as e:
+            logger.warning(f"Failed to decrypt token: {e}")
+            return None
+
+    def analyze_overlap(
+        self,
+        dataset1: DataFrame,
+        dataset2: DataFrame,
+        matching_rules: List[str],
+        dataset1_name: str = "Dataset1",
+        dataset2_name: str = "Dataset2"
+    ) -> Dict[str, any]:
+        """
+        Analyze overlap between two tokenized datasets based on matching rules.
+
+        Args:
+            dataset1: First tokenized DataFrame (must have columns: RecordId, RuleId, Token)
+            dataset2: Second tokenized DataFrame (must have columns: RecordId, RuleId, Token)
+            matching_rules: List of token rule IDs that define a match (e.g., ["T1", "T2", "T3"])
+                           A record is considered matching if it has matching tokens for ALL specified rules.
+            dataset1_name: Optional name for first dataset (for reporting)
+            dataset2_name: Optional name for second dataset (for reporting)
+
+        Returns:
+            Dictionary containing overlap analysis results:
+            - 'total_records_dataset1': Total unique records in dataset 1
+            - 'total_records_dataset2': Total unique records in dataset 2
+            - 'matching_records': Number of records with matches in both datasets
+            - 'unique_to_dataset1': Records only in dataset 1
+            - 'unique_to_dataset2': Records only in dataset 2
+            - 'overlap_percentage': Percentage of overlap
+            - 'matches': DataFrame with matched record pairs
+
+        Raises:
+            ValueError: If datasets don't have required columns or matching_rules is empty
+
+        Example:
+            >>> analyzer = OpenTokenOverlapAnalyzer("encryption-key-32-characters!!")
+            >>> # Match on T1 and T2 tokens (both must match)
+            >>> results = analyzer.analyze_overlap(tokens_df1, tokens_df2, ["T1", "T2"])
+            >>> print(f"Matching records: {results['matching_records']}")
+            >>> print(f"Overlap: {results['overlap_percentage']:.2f}%")
+        """
+        # Validate inputs
+        required_cols = {"RecordId", "RuleId", "Token"}
+        for df, name in [(dataset1, dataset1_name), (dataset2, dataset2_name)]:
+            if not required_cols.issubset(set(df.columns)):
+                raise ValueError(
+                    f"{name} must have columns: {required_cols}. "
+                    f"Got: {set(df.columns)}"
+                )
+
+        if not matching_rules:
+            raise ValueError("matching_rules cannot be empty")
+
+        # Filter datasets to only include specified matching rules
+        df1_filtered = dataset1.filter(col("RuleId").isin(matching_rules))
+        df2_filtered = dataset2.filter(col("RuleId").isin(matching_rules))
+
+        # Get unique records in each dataset
+        total_records_df1 = dataset1.select("RecordId").distinct().count()
+        total_records_df2 = dataset2.select("RecordId").distinct().count()
+
+        # Join on Token and RuleId to find matches
+        matches = df1_filtered.alias("df1").join(
+            df2_filtered.alias("df2"),
+            (col("df1.Token") == col("df2.Token")) & (col("df1.RuleId") == col("df2.RuleId")),
+            "inner"
+        ).select(
+            col("df1.RecordId").alias(f"{dataset1_name}_RecordId"),
+            col("df2.RecordId").alias(f"{dataset2_name}_RecordId"),
+            col("df1.RuleId").alias("RuleId"),
+            col("df1.Token").alias("Token")
+        )
+
+        # Count matches per record pair
+        # A valid match requires matching tokens for ALL specified rules
+        match_counts = matches.groupBy(
+            f"{dataset1_name}_RecordId",
+            f"{dataset2_name}_RecordId"
+        ).agg(
+            count("*").alias("matched_rules_count")
+        ).filter(
+            col("matched_rules_count") == len(matching_rules)
+        )
+
+        # Get unique matching records
+        matching_records_df1 = match_counts.select(
+            f"{dataset1_name}_RecordId"
+        ).distinct().count()
+        matching_records_df2 = match_counts.select(
+            f"{dataset2_name}_RecordId"
+        ).distinct().count()
+
+        # Calculate unique records
+        unique_to_df1 = total_records_df1 - matching_records_df1
+        unique_to_df2 = total_records_df2 - matching_records_df2
+
+        # Calculate overlap percentage (based on smaller dataset)
+        smaller_dataset_size = min(total_records_df1, total_records_df2)
+        overlap_percentage = (
+            (min(matching_records_df1, matching_records_df2) / smaller_dataset_size * 100)
+            if smaller_dataset_size > 0 else 0
+        )
+
+        # Get detailed matches
+        detailed_matches = matches.groupBy(
+            f"{dataset1_name}_RecordId",
+            f"{dataset2_name}_RecordId"
+        ).agg(
+            count("*").alias("matched_rules_count")
+        ).filter(
+            col("matched_rules_count") == len(matching_rules)
+        ).drop("matched_rules_count")
+
+        return {
+            'total_records_dataset1': total_records_df1,
+            'total_records_dataset2': total_records_df2,
+            'matching_records_dataset1': matching_records_df1,
+            'matching_records_dataset2': matching_records_df2,
+            'unique_to_dataset1': unique_to_df1,
+            'unique_to_dataset2': unique_to_df2,
+            'overlap_percentage': overlap_percentage,
+            'matches': detailed_matches,
+            'dataset1_name': dataset1_name,
+            'dataset2_name': dataset2_name,
+            'matching_rules': matching_rules
+        }
+
+    def compare_with_multiple_rules(
+        self,
+        dataset1: DataFrame,
+        dataset2: DataFrame,
+        rule_sets: List[List[str]],
+        dataset1_name: str = "Dataset1",
+        dataset2_name: str = "Dataset2"
+    ) -> List[Dict[str, any]]:
+        """
+        Compare datasets using multiple different matching rule sets.
+
+        This allows you to see how overlap changes with different matching criteria.
+        For example, compare overlap when requiring T1+T2 vs T1+T2+T3.
+
+        Args:
+            dataset1: First tokenized DataFrame
+            dataset2: Second tokenized DataFrame
+            rule_sets: List of rule sets to try (e.g., [["T1"], ["T1", "T2"], ["T1", "T2", "T3"]])
+            dataset1_name: Optional name for first dataset
+            dataset2_name: Optional name for second dataset
+
+        Returns:
+            List of analysis results, one for each rule set
+
+        Example:
+            >>> analyzer = OpenTokenOverlapAnalyzer("encryption-key-32-characters!!")
+            >>> rule_sets = [["T1"], ["T1", "T2"], ["T1", "T2", "T3"]]
+            >>> results = analyzer.compare_with_multiple_rules(df1, df2, rule_sets)
+            >>> for result in results:
+            ...     print(f"Rules {result['matching_rules']}: {result['overlap_percentage']:.2f}%")
+        """
+        results = []
+        for rules in rule_sets:
+            result = self.analyze_overlap(
+                dataset1, dataset2, rules, dataset1_name, dataset2_name
+            )
+            results.append(result)
+        return results
+
+    def print_summary(self, results: Dict[str, any]) -> None:
+        """
+        Print a formatted summary of overlap analysis results.
+
+        Args:
+            results: Results dictionary from analyze_overlap()
+
+        Example:
+            >>> results = analyzer.analyze_overlap(df1, df2, ["T1", "T2"])
+            >>> analyzer.print_summary(results)
+        """
+        print("=" * 70)
+        print(f"Dataset Overlap Analysis")
+        print("=" * 70)
+        print(f"Dataset 1: {results['dataset1_name']}")
+        print(f"  Total records: {results['total_records_dataset1']:,}")
+        print(f"  Matching records: {results['matching_records_dataset1']:,}")
+        print(f"  Unique records: {results['unique_to_dataset1']:,}")
+        print()
+        print(f"Dataset 2: {results['dataset2_name']}")
+        print(f"  Total records: {results['total_records_dataset2']:,}")
+        print(f"  Matching records: {results['matching_records_dataset2']:,}")
+        print(f"  Unique records: {results['unique_to_dataset2']:,}")
+        print()
+        print(f"Matching Rules: {', '.join(results['matching_rules'])}")
+        print(f"Overlap Percentage: {results['overlap_percentage']:.2f}%")
+        print("=" * 70)

--- a/lib/python/opentoken-pyspark/src/main/opentoken_pyspark/token_processor.py
+++ b/lib/python/opentoken-pyspark/src/main/opentoken_pyspark/token_processor.py
@@ -1,0 +1,352 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+
+PySpark token processor for distributed token generation.
+"""
+
+import logging
+from typing import Dict, Type, Optional
+from pyspark.sql import DataFrame
+from pyspark.sql.functions import pandas_udf, col
+from pyspark.sql.types import StructType, StructField, StringType, ArrayType
+import pandas as pd
+
+# Import OpenToken core functionality
+from opentoken.attributes.attribute import Attribute
+from opentoken.attributes.attribute_loader import AttributeLoader
+from opentoken.attributes.person.first_name_attribute import FirstNameAttribute
+from opentoken.attributes.person.last_name_attribute import LastNameAttribute
+from opentoken.attributes.person.birth_date_attribute import BirthDateAttribute
+from opentoken.attributes.person.sex_attribute import SexAttribute
+from opentoken.attributes.person.postal_code_attribute import PostalCodeAttribute
+from opentoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
+from opentoken.attributes.general.record_id_attribute import RecordIdAttribute
+from opentoken.tokens.token_definition import TokenDefinition
+from opentoken.tokens.base_token_definition import BaseTokenDefinition
+from opentoken.tokens.token_generator import TokenGenerator
+from opentoken.tokentransformer.hash_token_transformer import HashTokenTransformer
+from opentoken.tokentransformer.encrypt_token_transformer import EncryptTokenTransformer
+
+
+logger = logging.getLogger(__name__)
+
+
+class OpenTokenProcessor:
+    """
+    Process PySpark DataFrames to generate OpenTokens.
+
+    This class provides a bridge between PySpark DataFrames and OpenToken
+    token generation functionality, enabling distributed token generation
+    across a Spark cluster.
+    """
+
+    # Standard column mappings (column name -> attribute class)
+    # Built dynamically from attribute classes
+    COLUMN_MAPPINGS: Dict[str, Type[Attribute]] = None
+
+    @classmethod
+    def _build_column_mappings(cls) -> Dict[str, Type[Attribute]]:
+        """
+        Build column name to attribute class mappings dynamically from loaded attributes.
+
+        Returns:
+            Dictionary mapping column names to their corresponding attribute classes.
+        """
+        if cls.COLUMN_MAPPINGS is not None:
+            return cls.COLUMN_MAPPINGS
+
+        mappings = {}
+        for attribute in AttributeLoader.load():
+            attribute_class = type(attribute)
+            for alias in attribute.get_aliases():
+                mappings[alias] = attribute_class
+
+        # Add DateOfBirth as an alias for BirthDate for backward compatibility
+        # (documented in README but not in BirthDateAttribute.ALIASES)
+        if "BirthDate" in mappings:
+            mappings["DateOfBirth"] = mappings["BirthDate"]
+
+        cls.COLUMN_MAPPINGS = mappings
+        return mappings
+
+    def __init__(self, hashing_secret: str, encryption_key: str,
+                 token_definition: Optional[BaseTokenDefinition] = None):
+        """
+        Initialize the OpenToken processor with secrets.
+
+        Args:
+            hashing_secret: Secret for HMAC-SHA256 hashing
+            encryption_key: Key for AES-256 encryption
+            token_definition: Optional custom token definition. If None, uses default tokens (T1-T5).
+                             Use this to pass custom tokens created with TokenBuilder or CustomTokenDefinition.
+
+        Raises:
+            ValueError: If secrets are empty or invalid
+
+        Example:
+            >>> # Using default tokens
+            >>> processor = OpenTokenProcessor("hash-secret", "encryption-key-32-characters!!")
+            >>>
+            >>> # Using custom token definition
+            >>> from opentoken.notebook_helpers import TokenBuilder, CustomTokenDefinition
+            >>> custom_token = TokenBuilder("T6").add("last_name", "T|U").add("first_name", "T|U").build()
+            >>> custom_def = CustomTokenDefinition().add_token(custom_token)
+            >>> processor = OpenTokenProcessor("hash-secret", "encryption-key-32-chars!!", custom_def)
+        """
+        if not hashing_secret or not hashing_secret.strip():
+            raise ValueError("Hashing secret cannot be empty")
+        if not encryption_key or not encryption_key.strip():
+            raise ValueError("Encryption key cannot be empty")
+
+        self.hashing_secret = hashing_secret
+        self.encryption_key = encryption_key
+        self.token_definition = token_definition  # Store custom token definition
+
+        # Build column mappings if not already built
+        self._build_column_mappings()
+
+        # Validate secrets can initialize transformers
+        try:
+            HashTokenTransformer(hashing_secret)
+            EncryptTokenTransformer(encryption_key)
+        except Exception as e:
+            logger.error("Error initializing token transformers", exc_info=e)
+            raise ValueError(f"Invalid secrets provided: {e}")
+
+    def process_dataframe(self, df: DataFrame) -> DataFrame:
+        """
+        Process a PySpark DataFrame and generate tokens for each record.
+
+        The input DataFrame must contain the following columns (case-sensitive alternatives listed):
+        - RecordId or Id (optional - auto-generated if not provided)
+        - FirstName or GivenName
+        - LastName or Surname
+        - BirthDate or DateOfBirth
+        - Sex or Gender
+        - PostalCode or ZipCode
+        - SocialSecurityNumber or NationalIdentificationNumber
+
+        Args:
+            df: Input PySpark DataFrame with person attributes
+
+        Returns:
+            DataFrame with columns: RecordId, RuleId, Token
+
+        Raises:
+            ValueError: If required columns are missing or invalid
+        """
+        # Validate input DataFrame
+        self._validate_dataframe(df)
+
+        # Get the secrets and token definition for the UDF
+        hashing_secret = self.hashing_secret
+        encryption_key = self.encryption_key
+        token_definition = self.token_definition
+
+        # Define the schema for the output (array of structs)
+        token_schema = ArrayType(StructType([
+            StructField("RuleId", StringType(), False),
+            StructField("Token", StringType(), False)
+        ]))
+
+        # Create a pandas UDF for token generation
+        @pandas_udf(token_schema)
+        def generate_tokens_udf(
+            record_id_series: pd.Series,
+            first_name_series: pd.Series,
+            last_name_series: pd.Series,
+            birth_date_series: pd.Series,
+            sex_series: pd.Series,
+            postal_code_series: pd.Series,
+            ssn_series: pd.Series
+        ) -> pd.Series:
+            """
+            Pandas UDF to generate tokens for a batch of records.
+
+            This function is executed on each partition of the DataFrame
+            in parallel across the Spark cluster.
+            """
+            # Initialize token transformers
+            token_transformer_list = [
+                HashTokenTransformer(hashing_secret),
+                EncryptTokenTransformer(encryption_key)
+            ]
+
+            # Use custom token definition if provided, otherwise use default
+            definition = token_definition if token_definition is not None else TokenDefinition()
+
+            # Initialize token generator
+            token_generator = TokenGenerator(
+                definition, token_transformer_list
+            )
+
+            results = []
+
+            # Process each row in the batch
+            for idx in range(len(record_id_series)):
+                # Build person attributes dictionary
+                person_attrs = {
+                    RecordIdAttribute: str(record_id_series.iloc[idx])
+                    if pd.notna(record_id_series.iloc[idx]) else None,
+                    FirstNameAttribute: str(first_name_series.iloc[idx])
+                    if pd.notna(first_name_series.iloc[idx]) else None,
+                    LastNameAttribute: str(last_name_series.iloc[idx])
+                    if pd.notna(last_name_series.iloc[idx]) else None,
+                    BirthDateAttribute: str(birth_date_series.iloc[idx])
+                    if pd.notna(birth_date_series.iloc[idx]) else None,
+                    SexAttribute: str(sex_series.iloc[idx])
+                    if pd.notna(sex_series.iloc[idx]) else None,
+                    PostalCodeAttribute: str(postal_code_series.iloc[idx])
+                    if pd.notna(postal_code_series.iloc[idx]) else None,
+                    SocialSecurityNumberAttribute: str(ssn_series.iloc[idx])
+                    if pd.notna(ssn_series.iloc[idx]) else None,
+                }
+
+                # Generate tokens for this record
+                try:
+                    token_result = token_generator.get_all_tokens(person_attrs)
+
+                    # Convert to list of dicts for this record
+                    tokens_list = [
+                        {"RuleId": rule_id, "Token": token}
+                        for rule_id, token in token_result.tokens.items()
+                    ]
+
+                    results.append(tokens_list)
+                except Exception as e:
+                    logger.error(f"Error generating tokens for record: {e}")
+                    # Return empty list for failed records
+                    results.append([])
+
+            return pd.Series(results)
+
+        # Normalize column names - find the actual column names in the DataFrame
+        column_mapping = self._get_column_mapping(df)
+
+        # Apply the UDF to generate tokens
+        tokens_df = df.select(
+            col(column_mapping["RecordId"]).alias("RecordId"),
+            col(column_mapping["FirstName"]).alias("FirstName"),
+            col(column_mapping["LastName"]).alias("LastName"),
+            col(column_mapping["BirthDate"]).alias("BirthDate"),
+            col(column_mapping["Sex"]).alias("Sex"),
+            col(column_mapping["PostalCode"]).alias("PostalCode"),
+            col(column_mapping["SocialSecurityNumber"]).alias("SocialSecurityNumber")
+        ).withColumn(
+            "tokens",
+            generate_tokens_udf(
+                col("RecordId"),
+                col("FirstName"),
+                col("LastName"),
+                col("BirthDate"),
+                col("Sex"),
+                col("PostalCode"),
+                col("SocialSecurityNumber")
+            )
+        )
+
+        # Explode the tokens array to get one row per token
+        from pyspark.sql.functions import explode
+        result_df = tokens_df.select(
+            col("RecordId"),
+            explode(col("tokens")).alias("token_struct")
+        ).select(
+            col("RecordId"),
+            col("token_struct.RuleId").alias("RuleId"),
+            col("token_struct.Token").alias("Token")
+        )
+
+        return result_df
+
+    @classmethod
+    def _get_required_attribute_groups(cls) -> Dict[str, list]:
+        """
+        Get required attribute groups with their column name variants.
+
+        Returns:
+            Dictionary mapping attribute names to their column name variants.
+        """
+        # Required attributes for token generation (excluding RecordId which is optional)
+        required_attribute_classes = [
+            FirstNameAttribute,
+            LastNameAttribute,
+            BirthDateAttribute,
+            SexAttribute,
+            PostalCodeAttribute,
+            SocialSecurityNumberAttribute,
+        ]
+
+        groups = {}
+        for attr_class in required_attribute_classes:
+            attr_instance = attr_class()
+            attr_name = attr_instance.get_name()
+            aliases = attr_instance.get_aliases()
+
+            # Add DateOfBirth for BirthDate if not already present
+            if attr_name == "BirthDate" and "DateOfBirth" not in aliases:
+                aliases = aliases + ["DateOfBirth"]
+
+            groups[attr_name] = aliases
+
+        return groups
+
+    def _validate_dataframe(self, df: DataFrame) -> None:
+        """
+        Validate that the DataFrame has all required columns.
+
+        Args:
+            df: DataFrame to validate
+
+        Raises:
+            ValueError: If required columns are missing
+        """
+        if df is None:
+            raise ValueError("DataFrame cannot be None")
+
+        df_columns = set(df.columns)
+
+        # Get required attribute groups dynamically
+        required_groups = self._get_required_attribute_groups()
+
+        missing = []
+        for group_name, variants in required_groups.items():
+            if not any(col in df_columns for col in variants):
+                missing.append(f"{group_name} (or variants: {', '.join(variants)})")
+
+        if missing:
+            raise ValueError(f"Missing required columns: {', '.join(missing)}")
+
+    def _get_column_mapping(self, df: DataFrame) -> Dict[str, str]:
+        """
+        Map standard attribute names to actual column names in the DataFrame.
+
+        Args:
+            df: DataFrame to map columns from
+
+        Returns:
+            Dictionary mapping standard names to actual column names
+        """
+        df_columns = set(df.columns)
+        mapping = {}
+
+        # Get all attribute groups (including optional RecordId)
+        column_groups = self._get_required_attribute_groups()
+
+        # Add RecordId separately since it's optional
+        record_id_attr = RecordIdAttribute()
+        record_id_aliases = record_id_attr.get_aliases()
+        column_groups[record_id_attr.get_name()] = record_id_aliases
+
+        # Find the first matching column for each group
+        for standard_name, variants in column_groups.items():
+            for variant in variants:
+                if variant in df_columns:
+                    mapping[standard_name] = variant
+                    break
+
+            # RecordId is optional, provide a default
+            if standard_name == "RecordId" and standard_name not in mapping:
+                # We'll need to generate RecordIds - use a placeholder for now
+                mapping[standard_name] = variants[0]
+
+        return mapping

--- a/lib/python/opentoken-pyspark/src/test/opentoken_pyspark/__init__.py
+++ b/lib/python/opentoken-pyspark/src/test/opentoken_pyspark/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for opentoken_pyspark."""

--- a/lib/python/opentoken-pyspark/src/test/opentoken_pyspark/overlap_analyzer_test.py
+++ b/lib/python/opentoken-pyspark/src/test/opentoken_pyspark/overlap_analyzer_test.py
@@ -1,0 +1,261 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+
+Tests for dataset overlap analyzer.
+"""
+
+import pytest
+from pyspark.sql import SparkSession
+from opentoken_pyspark.overlap_analyzer import OpenTokenOverlapAnalyzer
+
+
+@pytest.fixture(scope="module")
+def spark():
+    """Create a Spark session for testing."""
+    return SparkSession.builder \
+        .appName("OverlapAnalyzerTest") \
+        .master("local[2]") \
+        .getOrCreate()
+
+
+@pytest.fixture
+def encryption_key():
+    """Standard 32-character encryption key for testing."""
+    return "test-encryption-key-32-chars!!"
+
+
+@pytest.fixture
+def sample_tokens_df1(spark):
+    """Create sample tokenized dataset 1."""
+    data = [
+        ("rec1", "T1", "token_a_t1"),
+        ("rec1", "T2", "token_a_t2"),
+        ("rec1", "T3", "token_a_t3"),
+        ("rec2", "T1", "token_b_t1"),
+        ("rec2", "T2", "token_b_t2"),
+        ("rec2", "T3", "token_b_t3"),
+        ("rec3", "T1", "token_c_t1"),
+        ("rec3", "T2", "token_c_t2"),
+        ("rec3", "T3", "token_c_t3"),
+    ]
+    return spark.createDataFrame(data, ["RecordId", "RuleId", "Token"])
+
+
+@pytest.fixture
+def sample_tokens_df2(spark):
+    """Create sample tokenized dataset 2 with some overlap."""
+    data = [
+        ("rec10", "T1", "token_a_t1"),  # Matches rec1 from df1
+        ("rec10", "T2", "token_a_t2"),
+        ("rec10", "T3", "token_a_t3"),
+        ("rec11", "T1", "token_b_t1"),  # Matches rec2 from df1
+        ("rec11", "T2", "token_b_t2"),
+        ("rec11", "T3", "token_b_t3"),
+        ("rec12", "T1", "token_d_t1"),  # Unique to df2
+        ("rec12", "T2", "token_d_t2"),
+        ("rec12", "T3", "token_d_t3"),
+    ]
+    return spark.createDataFrame(data, ["RecordId", "RuleId", "Token"])
+
+
+class TestOpenTokenOverlapAnalyzerInit:
+    """Tests for OpenTokenOverlapAnalyzer initialization."""
+
+    def test_init_valid_key(self, encryption_key):
+        """Test initialization with valid encryption key."""
+        analyzer = OpenTokenOverlapAnalyzer(encryption_key)
+        assert analyzer.encryption_key == encryption_key.encode('utf-8')
+
+    def test_init_empty_key(self):
+        """Test initialization with empty key raises ValueError."""
+        with pytest.raises(ValueError, match="Encryption key cannot be empty"):
+            OpenTokenOverlapAnalyzer("")
+
+    def test_init_invalid_key_length(self):
+        """Test initialization with wrong key length raises ValueError."""
+        with pytest.raises(ValueError, match="must be exactly 32 bytes"):
+            OpenTokenOverlapAnalyzer("short-key")
+
+
+class TestAnalyzeOverlap:
+    """Tests for overlap analysis functionality."""
+
+    def test_analyze_overlap_single_rule(
+        self, spark, encryption_key, sample_tokens_df1, sample_tokens_df2
+    ):
+        """Test overlap analysis with single matching rule."""
+        analyzer = OpenTokenOverlapAnalyzer(encryption_key)
+        results = analyzer.analyze_overlap(
+            sample_tokens_df1, sample_tokens_df2, ["T1"]
+        )
+
+        assert results['total_records_dataset1'] == 3
+        assert results['total_records_dataset2'] == 3
+        assert results['matching_records_dataset1'] == 2  # rec1, rec2
+        assert results['matching_records_dataset2'] == 2  # rec10, rec11
+        assert results['unique_to_dataset1'] == 1  # rec3
+        assert results['unique_to_dataset2'] == 1  # rec12
+        assert results['overlap_percentage'] > 0
+
+    def test_analyze_overlap_multiple_rules(
+        self, spark, encryption_key, sample_tokens_df1, sample_tokens_df2
+    ):
+        """Test overlap analysis requiring multiple matching rules."""
+        analyzer = OpenTokenOverlapAnalyzer(encryption_key)
+        results = analyzer.analyze_overlap(
+            sample_tokens_df1, sample_tokens_df2, ["T1", "T2", "T3"]
+        )
+
+        # Should match on all three rules
+        assert results['matching_records_dataset1'] == 2  # rec1, rec2
+        assert results['matching_records_dataset2'] == 2  # rec10, rec11
+
+    def test_analyze_overlap_no_matches(self, spark, encryption_key):
+        """Test overlap analysis with no matching records."""
+        df1_data = [
+            ("rec1", "T1", "token_a"),
+            ("rec1", "T2", "token_b"),
+        ]
+        df2_data = [
+            ("rec2", "T1", "token_c"),
+            ("rec2", "T2", "token_d"),
+        ]
+        df1 = spark.createDataFrame(df1_data, ["RecordId", "RuleId", "Token"])
+        df2 = spark.createDataFrame(df2_data, ["RecordId", "RuleId", "Token"])
+
+        analyzer = OpenTokenOverlapAnalyzer(encryption_key)
+        results = analyzer.analyze_overlap(df1, df2, ["T1"])
+
+        assert results['matching_records_dataset1'] == 0
+        assert results['matching_records_dataset2'] == 0
+        assert results['overlap_percentage'] == 0
+
+    def test_analyze_overlap_custom_dataset_names(
+        self, encryption_key, sample_tokens_df1, sample_tokens_df2
+    ):
+        """Test overlap analysis with custom dataset names."""
+        analyzer = OpenTokenOverlapAnalyzer(encryption_key)
+        results = analyzer.analyze_overlap(
+            sample_tokens_df1,
+            sample_tokens_df2,
+            ["T1"],
+            dataset1_name="Hospital_A",
+            dataset2_name="Hospital_B"
+        )
+
+        assert results['dataset1_name'] == "Hospital_A"
+        assert results['dataset2_name'] == "Hospital_B"
+        assert "Hospital_A_RecordId" in results['matches'].columns
+        assert "Hospital_B_RecordId" in results['matches'].columns
+
+    def test_analyze_overlap_missing_columns(
+        self, spark, encryption_key
+    ):
+        """Test that missing columns raise ValueError."""
+        df_invalid = spark.createDataFrame(
+            [("rec1", "token")],
+            ["RecordId", "Token"]  # Missing RuleId
+        )
+        df_valid = spark.createDataFrame(
+            [("rec1", "T1", "token")],
+            ["RecordId", "RuleId", "Token"]
+        )
+
+        analyzer = OpenTokenOverlapAnalyzer(encryption_key)
+        with pytest.raises(ValueError, match="must have columns"):
+            analyzer.analyze_overlap(df_invalid, df_valid, ["T1"])
+
+    def test_analyze_overlap_empty_rules(
+        self, encryption_key, sample_tokens_df1, sample_tokens_df2
+    ):
+        """Test that empty matching rules raise ValueError."""
+        analyzer = OpenTokenOverlapAnalyzer(encryption_key)
+        with pytest.raises(ValueError, match="matching_rules cannot be empty"):
+            analyzer.analyze_overlap(
+                sample_tokens_df1, sample_tokens_df2, []
+            )
+
+    def test_analyze_overlap_matches_dataframe(
+        self, encryption_key, sample_tokens_df1, sample_tokens_df2
+    ):
+        """Test that matches DataFrame is returned correctly."""
+        analyzer = OpenTokenOverlapAnalyzer(encryption_key)
+        results = analyzer.analyze_overlap(
+            sample_tokens_df1, sample_tokens_df2, ["T1"]
+        )
+
+        matches_df = results['matches']
+        assert matches_df.count() == 2  # rec1-rec10, rec2-rec11
+        assert "Dataset1_RecordId" in matches_df.columns
+        assert "Dataset2_RecordId" in matches_df.columns
+
+
+class TestCompareWithMultipleRules:
+    """Tests for comparing with multiple rule sets."""
+
+    def test_compare_with_multiple_rules(
+        self, encryption_key, sample_tokens_df1, sample_tokens_df2
+    ):
+        """Test comparison with multiple rule sets."""
+        analyzer = OpenTokenOverlapAnalyzer(encryption_key)
+        rule_sets = [["T1"], ["T1", "T2"], ["T1", "T2", "T3"]]
+        results = analyzer.compare_with_multiple_rules(
+            sample_tokens_df1, sample_tokens_df2, rule_sets
+        )
+
+        assert len(results) == 3
+        for result in results:
+            assert 'overlap_percentage' in result
+            assert 'matching_records_dataset1' in result
+
+    def test_compare_different_overlap_rates(
+        self, spark, encryption_key
+    ):
+        """Test that different rules produce different overlap rates."""
+        # Create datasets where T1 matches but T2 doesn't for some records
+        df1_data = [
+            ("rec1", "T1", "token_a"),
+            ("rec1", "T2", "token_b"),
+            ("rec2", "T1", "token_c"),
+            ("rec2", "T2", "token_d"),
+        ]
+        df2_data = [
+            ("rec10", "T1", "token_a"),  # T1 matches
+            ("rec10", "T2", "token_x"),  # T2 doesn't match
+            ("rec11", "T1", "token_c"),  # T1 matches
+            ("rec11", "T2", "token_d"),  # T2 matches
+        ]
+        df1 = spark.createDataFrame(df1_data, ["RecordId", "RuleId", "Token"])
+        df2 = spark.createDataFrame(df2_data, ["RecordId", "RuleId", "Token"])
+
+        analyzer = OpenTokenOverlapAnalyzer(encryption_key)
+        rule_sets = [["T1"], ["T1", "T2"]]
+        results = analyzer.compare_with_multiple_rules(df1, df2, rule_sets)
+
+        # T1 only should match both records
+        assert results[0]['matching_records_dataset1'] == 2
+        # T1+T2 should match only one record
+        assert results[1]['matching_records_dataset1'] == 1
+
+
+class TestPrintSummary:
+    """Tests for summary printing functionality."""
+
+    def test_print_summary_no_error(
+        self, encryption_key, sample_tokens_df1, sample_tokens_df2, capsys
+    ):
+        """Test that print_summary executes without error."""
+        analyzer = OpenTokenOverlapAnalyzer(encryption_key)
+        results = analyzer.analyze_overlap(
+            sample_tokens_df1, sample_tokens_df2, ["T1"]
+        )
+
+        # Should not raise any exceptions
+        analyzer.print_summary(results)
+
+        # Verify output contains expected elements
+        captured = capsys.readouterr()
+        assert "Dataset Overlap Analysis" in captured.out
+        assert "Total records:" in captured.out
+        assert "Matching records:" in captured.out
+        assert "Overlap Percentage:" in captured.out

--- a/lib/python/opentoken-pyspark/src/test/opentoken_pyspark/token_processor_test.py
+++ b/lib/python/opentoken-pyspark/src/test/opentoken_pyspark/token_processor_test.py
@@ -1,0 +1,312 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+
+Tests for OpenToken PySpark token processor.
+"""
+
+import pytest
+from pyspark.sql import SparkSession
+from pyspark.sql.types import StructType, StructField, StringType
+from opentoken_pyspark import OpenTokenProcessor
+
+
+@pytest.fixture(scope="module")
+def spark():
+    """Create a Spark session for testing."""
+    spark = SparkSession.builder \
+        .appName("OpenTokenTest") \
+        .master("local[2]") \
+        .config("spark.sql.shuffle.partitions", "2") \
+        .getOrCreate()
+    yield spark
+    spark.stop()
+
+
+@pytest.fixture
+def sample_data():
+    """Sample person data for testing."""
+    return [
+        {
+            "RecordId": "891dda6c-961f-4154-8541-b48fe18ee620",
+            "FirstName": "John",
+            "LastName": "Doe",
+            "PostalCode": "98004",
+            "Sex": "Male",
+            "BirthDate": "2000-01-01",
+            "SocialSecurityNumber": "123-45-6789"
+        },
+        {
+            "RecordId": "2f97f0f1-4617-40bd-8264-4d24a9adf20a",
+            "FirstName": "Joe",
+            "LastName": "Price",
+            "PostalCode": "15635",
+            "Sex": "Male",
+            "BirthDate": "1951-10-22",
+            "SocialSecurityNumber": "172-10-0983"
+        }
+    ]
+
+
+class TestOpenTokenProcessor:
+    """Tests for OpenTokenProcessor class."""
+
+    def test_initialization_with_valid_secrets(self):
+        """Test that processor initializes with valid secrets."""
+        processor = OpenTokenProcessor("HashingKey", "Secret-Encryption-Key-Goes-Here.")
+        assert processor.hashing_secret == "HashingKey"
+        assert processor.encryption_key == "Secret-Encryption-Key-Goes-Here."
+
+    def test_initialization_with_empty_hashing_secret(self):
+        """Test that initialization fails with empty hashing secret."""
+        with pytest.raises(ValueError, match="Hashing secret cannot be empty"):
+            OpenTokenProcessor("", "Secret-Encryption-Key-Goes-Here.")
+
+    def test_initialization_with_empty_encryption_key(self):
+        """Test that initialization fails with empty encryption key."""
+        with pytest.raises(ValueError, match="Encryption key cannot be empty"):
+            OpenTokenProcessor("HashingKey", "")
+
+    def test_initialization_with_whitespace_secrets(self):
+        """Test that initialization fails with whitespace-only secrets."""
+        with pytest.raises(ValueError, match="Hashing secret cannot be empty"):
+            OpenTokenProcessor("   ", "Secret-Encryption-Key-Goes-Here.")
+
+    def test_process_dataframe_with_valid_data(self, spark, sample_data):
+        """Test processing a DataFrame with valid data."""
+        processor = OpenTokenProcessor("HashingKey", "Secret-Encryption-Key-Goes-Here.")
+
+        # Create DataFrame
+        df = spark.createDataFrame(sample_data)
+
+        # Process the DataFrame
+        result_df = processor.process_dataframe(df)
+
+        # Verify result structure
+        assert "RecordId" in result_df.columns
+        assert "RuleId" in result_df.columns
+        assert "Token" in result_df.columns
+
+        # Collect results
+        results = result_df.collect()
+
+        # Should have tokens for each record (5 tokens per record)
+        assert len(results) > 0
+
+        # Verify we have multiple rule IDs
+        rule_ids = set(row.RuleId for row in results)
+        assert len(rule_ids) > 1
+
+    def test_process_dataframe_with_alternative_column_names(self, spark):
+        """Test processing with alternative column names."""
+        processor = OpenTokenProcessor("HashingKey", "Secret-Encryption-Key-Goes-Here.")
+
+        # Create DataFrame with alternative column names
+        data = [{
+            "Id": "test-123",
+            "GivenName": "John",
+            "Surname": "Doe",
+            "ZipCode": "98004",
+            "Gender": "Male",
+            "DateOfBirth": "2000-01-01",
+            "NationalIdentificationNumber": "123-45-6789"
+        }]
+
+        df = spark.createDataFrame(data)
+
+        # Process should work with alternative names
+        result_df = processor.process_dataframe(df)
+
+        # Verify result
+        assert result_df.count() > 0
+
+    def test_process_dataframe_with_missing_required_column(self, spark):
+        """Test that processing fails with missing required columns."""
+        processor = OpenTokenProcessor("HashingKey", "Secret-Encryption-Key-Goes-Here.")
+
+        # Create DataFrame missing SocialSecurityNumber
+        data = [{
+            "RecordId": "test-123",
+            "FirstName": "John",
+            "LastName": "Doe",
+            "PostalCode": "98004",
+            "Sex": "Male",
+            "BirthDate": "2000-01-01"
+        }]
+
+        df = spark.createDataFrame(data)
+
+        # Should raise ValueError
+        with pytest.raises(ValueError, match="Missing required columns"):
+            processor.process_dataframe(df)
+
+    def test_process_dataframe_with_none_dataframe(self):
+        """Test that processing fails with None DataFrame."""
+        processor = OpenTokenProcessor("HashingKey", "Secret-Encryption-Key-Goes-Here.")
+
+        with pytest.raises(ValueError, match="DataFrame cannot be None"):
+            processor.process_dataframe(None)
+
+    def test_tokens_are_consistent(self, spark, sample_data):
+        """Test that the same input produces the same tokens."""
+        processor = OpenTokenProcessor("HashingKey", "Secret-Encryption-Key-Goes-Here.")
+
+        # Create DataFrame
+        df = spark.createDataFrame(sample_data)
+
+        # Process twice
+        result1 = processor.process_dataframe(df).collect()
+        result2 = processor.process_dataframe(df).collect()
+
+        # Convert to sets for comparison (order might differ)
+        tokens1 = {(r.RecordId, r.RuleId, r.Token) for r in result1}
+        tokens2 = {(r.RecordId, r.RuleId, r.Token) for r in result2}
+
+        # Should be identical
+        assert tokens1 == tokens2
+
+    def test_different_secrets_produce_different_tokens(self, spark, sample_data):
+        """Test that different secrets produce different tokens."""
+        processor1 = OpenTokenProcessor("HashingKey1", "EncryptionKey1")
+        processor2 = OpenTokenProcessor("HashingKey2", "EncryptionKey2")
+
+        # Create DataFrame
+        df = spark.createDataFrame(sample_data)
+
+        # Process with different secrets
+        result1 = processor1.process_dataframe(df).collect()
+        result2 = processor2.process_dataframe(df).collect()
+
+        # Get tokens for the same record and rule
+        tokens1 = {(r.RecordId, r.RuleId, r.Token) for r in result1}
+        tokens2 = {(r.RecordId, r.RuleId, r.Token) for r in result2}
+
+        # Tokens should be different
+        assert tokens1 != tokens2
+
+    def test_column_mapping(self, spark):
+        """Test that column mapping works correctly."""
+        processor = OpenTokenProcessor("HashingKey", "Secret-Encryption-Key-Goes-Here.")
+
+        # Create DataFrame with various column names
+        data = [{
+            "RecordId": "test-1",
+            "FirstName": "John",
+            "LastName": "Doe",
+            "PostalCode": "98004",
+            "Sex": "Male",
+            "BirthDate": "2000-01-01",
+            "SocialSecurityNumber": "123-45-6789"
+        }]
+
+        df = spark.createDataFrame(data)
+
+        # Get column mapping
+        mapping = processor._get_column_mapping(df)
+
+        # Verify mapping
+        assert mapping["RecordId"] == "RecordId"
+        assert mapping["FirstName"] == "FirstName"
+        assert mapping["LastName"] == "LastName"
+        assert mapping["PostalCode"] == "PostalCode"
+        assert mapping["Sex"] == "Sex"
+        assert mapping["BirthDate"] == "BirthDate"
+        assert mapping["SocialSecurityNumber"] == "SocialSecurityNumber"
+
+    def test_validation_with_empty_dataframe(self, spark):
+        """Test validation with an empty DataFrame."""
+        processor = OpenTokenProcessor("HashingKey", "Secret-Encryption-Key-Goes-Here.")
+
+        # Create empty DataFrame with correct schema
+        schema = StructType([
+            StructField("RecordId", StringType(), True),
+            StructField("FirstName", StringType(), True),
+            StructField("LastName", StringType(), True),
+            StructField("PostalCode", StringType(), True),
+            StructField("Sex", StringType(), True),
+            StructField("BirthDate", StringType(), True),
+            StructField("SocialSecurityNumber", StringType(), True)
+        ])
+
+        df = spark.createDataFrame([], schema)
+
+        # Should not raise an error during validation
+        processor._validate_dataframe(df)
+
+        # Process should return empty DataFrame
+        result = processor.process_dataframe(df)
+        assert result.count() == 0
+
+    def test_custom_token_definition(self, spark, sample_data):
+        """Test using custom token definition with processor."""
+        from opentoken.notebook_helpers import TokenBuilder, CustomTokenDefinition
+
+        # Create a custom T6 token
+        t6_token = TokenBuilder("T6") \
+            .add("last_name", "T|U") \
+            .add("first_name", "T|U") \
+            .add("birth_date", "T|D") \
+            .build()
+
+        custom_definition = CustomTokenDefinition().add_token(t6_token)
+
+        # Create processor with custom definition
+        processor = OpenTokenProcessor(
+            hashing_secret="test-hash-secret",
+            encryption_key="12345678901234567890123456789012",
+            token_definition=custom_definition
+        )
+
+        # Create DataFrame
+        df = spark.createDataFrame(sample_data)
+
+        # Process with custom tokens
+        result = processor.process_dataframe(df)
+
+        # Verify we got T6 tokens (not default T1-T5)
+        rule_ids = [row.RuleId for row in result.select("RuleId").distinct().collect()]
+        assert "T6" in rule_ids
+        assert "T1" not in rule_ids  # Default tokens should not be present
+
+        # Verify we have tokens for each record
+        assert result.count() == len(sample_data)  # One T6 token per record
+
+    def test_multiple_custom_tokens(self, spark, sample_data):
+        """Test using multiple custom tokens."""
+        from opentoken.notebook_helpers import TokenBuilder, CustomTokenDefinition
+
+        # Create two custom tokens
+        t6_token = TokenBuilder("T6") \
+            .add("last_name", "T|U") \
+            .add("first_name", "T|U") \
+            .build()
+
+        t7_token = TokenBuilder("T7") \
+            .add("last_name", "T|S(0,3)|U") \
+            .add("birth_date", "T|D") \
+            .build()
+
+        custom_definition = CustomTokenDefinition() \
+            .add_token(t6_token) \
+            .add_token(t7_token)
+
+        # Create processor with multiple custom tokens
+        processor = OpenTokenProcessor(
+            hashing_secret="test-hash-secret",
+            encryption_key="12345678901234567890123456789012",
+            token_definition=custom_definition
+        )
+
+        # Create DataFrame
+        df = spark.createDataFrame(sample_data)
+
+        # Process with custom tokens
+        result = processor.process_dataframe(df)
+
+        # Verify we got both T6 and T7 tokens
+        rule_ids = [row.RuleId for row in result.select("RuleId").distinct().collect()]
+        assert "T6" in rule_ids
+        assert "T7" in rule_ids
+        assert "T1" not in rule_ids  # Default tokens should not be present
+
+        # Verify we have 2 tokens per record (T6 and T7)
+        assert result.count() == len(sample_data) * 2

--- a/lib/python/opentoken/src/main/opentoken/notebook_helpers.py
+++ b/lib/python/opentoken/src/main/opentoken/notebook_helpers.py
@@ -1,0 +1,283 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+
+Notebook helpers for convenient token definition and experimentation.
+This module provides a simplified API for creating custom tokens in Jupyter notebooks.
+"""
+
+from typing import List, Dict, Optional, Type, Union
+from opentoken.attributes.attribute import Attribute
+from opentoken.attributes.attribute_expression import AttributeExpression
+from opentoken.attributes.person.first_name_attribute import FirstNameAttribute
+from opentoken.attributes.person.last_name_attribute import LastNameAttribute
+from opentoken.attributes.person.birth_date_attribute import BirthDateAttribute
+from opentoken.attributes.person.sex_attribute import SexAttribute
+from opentoken.attributes.person.postal_code_attribute import PostalCodeAttribute
+from opentoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
+from opentoken.attributes.general.record_id_attribute import RecordIdAttribute
+from opentoken.tokens.token import Token
+from opentoken.tokens.base_token_definition import BaseTokenDefinition
+from opentoken.tokens.token_generator import TokenGenerator
+from opentoken.tokentransformer.hash_token_transformer import HashTokenTransformer
+from opentoken.tokentransformer.encrypt_token_transformer import EncryptTokenTransformer
+
+
+# Convenient attribute name mappings
+ATTRIBUTE_MAP = {
+    "first_name": FirstNameAttribute,
+    "last_name": LastNameAttribute,
+    "birth_date": BirthDateAttribute,
+    "sex": SexAttribute,
+    "postal_code": PostalCodeAttribute,
+    "ssn": SocialSecurityNumberAttribute,
+    "record_id": RecordIdAttribute,
+}
+
+
+class TokenBuilder:
+    """
+    A fluent builder for creating custom tokens with minimal code.
+
+    Example:
+        >>> token = TokenBuilder("T6") \\
+        ...     .add("last_name", "T|U") \\
+        ...     .add("first_name", "T|U") \\
+        ...     .add("birth_date", "T|D") \\
+        ...     .add("postal_code", "T|S(0,3)") \\
+        ...     .add("sex", "T|U") \\
+        ...     .build()
+    """
+
+    def __init__(self, token_id: str):
+        """
+        Initialize the token builder.
+
+        Args:
+            token_id: The identifier for the token (e.g., "T6", "T7").
+        """
+        self.token_id = token_id
+        self.expressions: List[AttributeExpression] = []
+
+    def add(self, attribute: Union[str, Type[Attribute]], expression: str = "T") -> 'TokenBuilder':
+        """
+        Add an attribute expression to the token definition.
+
+        Args:
+            attribute: Either an attribute class or a string name (e.g., "first_name", "last_name").
+            expression: The transformation expression (e.g., "T|U", "T|S(0,3)|U").
+
+        Returns:
+            Self for method chaining.
+
+        Example:
+            >>> builder.add("last_name", "T|U").add("first_name", "T|S(0,3)|U")
+        """
+        if isinstance(attribute, str):
+            if attribute not in ATTRIBUTE_MAP:
+                raise ValueError(
+                    f"Unknown attribute: {attribute}. "
+                    f"Available: {', '.join(ATTRIBUTE_MAP.keys())}"
+                )
+            attribute_class = ATTRIBUTE_MAP[attribute]
+        else:
+            attribute_class = attribute
+
+        self.expressions.append(AttributeExpression(attribute_class, expression))
+        return self
+
+    def build(self) -> Token:
+        """
+        Build the custom token.
+
+        Returns:
+            A Token instance with the configured expressions.
+        """
+        token_id = self.token_id
+        expressions = self.expressions
+
+        class CustomToken(Token):
+            """Dynamically created custom token."""
+
+            ID = token_id
+
+            def __init__(self):
+                self._definition = expressions
+
+            def get_identifier(self):
+                return self.ID
+
+            def get_definition(self):
+                return self._definition
+
+        return CustomToken()
+
+
+class CustomTokenDefinition(BaseTokenDefinition):
+    """
+    A custom token definition that can include multiple custom tokens.
+
+    Example:
+        >>> definition = CustomTokenDefinition()
+        >>> definition.add_token(t6_token)
+        >>> definition.add_token(t7_token)
+    """
+
+    def __init__(self):
+        """Initialize an empty custom token definition."""
+        self.tokens: Dict[str, Token] = {}
+
+    def add_token(self, token: Token) -> 'CustomTokenDefinition':
+        """
+        Add a custom token to the definition.
+
+        Args:
+            token: The token to add.
+
+        Returns:
+            Self for method chaining.
+        """
+        token_id = token.get_identifier()
+        self.tokens[token_id] = token
+        return self
+
+    def get_version(self) -> str:
+        """Get the version of the token definition."""
+        return "2.0-custom"
+
+    def get_token_identifiers(self) -> set:
+        """Get all token identifiers."""
+        return set(self.tokens.keys())
+
+    def get_token_definition(self, token_id: str) -> List[AttributeExpression]:
+        """Get the token definition for a given token identifier."""
+        token = self.tokens.get(token_id)
+        if token:
+            return token.get_definition()
+        return None
+
+
+def create_token_generator(
+    hashing_secret: str,
+    encryption_key: str,
+    token_definition: Optional[BaseTokenDefinition] = None
+) -> TokenGenerator:
+    """
+    Create a token generator with the specified secrets and token definition.
+
+    Args:
+        hashing_secret: The secret used for HMAC-SHA256 hashing.
+        encryption_key: The 32-character key used for AES-256 encryption.
+        token_definition: Optional custom token definition. If None, uses default tokens.
+
+    Returns:
+        A configured TokenGenerator instance.
+
+    Example:
+        >>> # Use default tokens (T1-T5)
+        >>> generator = create_token_generator("my-hash-secret", "my-32-character-encryption-key!")
+        >>>
+        >>> # Use custom tokens
+        >>> custom_def = CustomTokenDefinition().add_token(t6_token)
+        >>> generator = create_token_generator("secret", "key123...", custom_def)
+    """
+    if token_definition is None:
+        from opentoken.tokens.token_definition import TokenDefinition
+        token_definition = TokenDefinition()
+
+    token_transformers = [
+        HashTokenTransformer(hashing_secret),
+        EncryptTokenTransformer(encryption_key)
+    ]
+
+    return TokenGenerator(token_definition, token_transformers)
+
+
+def quick_token(
+    token_id: str,
+    attributes: List[tuple],
+    hashing_secret: str,
+    encryption_key: str
+) -> TokenGenerator:
+    """
+    Create a custom token and generator in one quick call.
+
+    Args:
+        token_id: The identifier for the new token (e.g., "T6").
+        attributes: List of (attribute_name, expression) tuples.
+        hashing_secret: The secret used for HMAC-SHA256 hashing.
+        encryption_key: The 32-character key used for AES-256 encryption.
+
+    Returns:
+        A TokenGenerator configured with the custom token.
+
+    Example:
+        >>> generator = quick_token(
+        ...     "T6",
+        ...     [
+        ...         ("last_name", "T|U"),
+        ...         ("first_name", "T|U"),
+        ...         ("birth_date", "T|D"),
+        ...         ("postal_code", "T|S(0,3)"),
+        ...         ("sex", "T|U")
+        ...     ],
+        ...     "my-hashing-secret",
+        ...     "my-32-character-encryption-key!"
+        ... )
+    """
+    builder = TokenBuilder(token_id)
+    for attr_name, expr in attributes:
+        builder.add(attr_name, expr)
+
+    token = builder.build()
+    definition = CustomTokenDefinition().add_token(token)
+
+    return create_token_generator(hashing_secret, encryption_key, definition)
+
+
+# Convenience function to list available attributes
+def list_attributes() -> Dict[str, Type[Attribute]]:
+    """
+    Get a dictionary of available attribute names and their classes.
+
+    Returns:
+        Dictionary mapping attribute names to their classes.
+
+    Example:
+        >>> attrs = list_attributes()
+        >>> print(attrs.keys())
+        dict_keys(['first_name', 'last_name', 'birth_date', 'sex', 'postal_code', 'ssn', 'record_id'])
+    """
+    return ATTRIBUTE_MAP.copy()
+
+
+def expression_help() -> str:
+    """
+    Get help text about expression syntax.
+
+    Returns:
+        A string describing the expression syntax.
+    """
+    return """
+Expression Syntax Guide:
+========================
+
+Components (separated by |):
+- T           : Trim whitespace
+- U           : Convert to uppercase
+- S(start,end): Substring (e.g., S(0,3) for first 3 characters)
+- D           : Format as date (yyyy-MM-dd)
+- M(regex)    : Match regular expression
+- R(old,new)  : Replace string
+
+Examples:
+- "T|U"         : Trim and uppercase (e.g., "  john  " → "JOHN")
+- "T|S(0,3)|U"  : Trim, take first 3 chars, uppercase (e.g., "john" → "JOH")
+- "T|D"         : Trim and format as date (e.g., "1990-01-15" → "1990-01-15")
+- "T|S(0,5)"    : Trim and take first 5 chars (e.g., "98101-1234" → "98101")
+
+Common Patterns:
+- Names:        "T|U" or "T|S(0,3)|U"
+- Dates:        "T|D"
+- Postal codes: "T|S(0,3)" or "T|S(0,5)"
+- Gender/Sex:   "T|U"
+"""

--- a/lib/python/opentoken/src/test/opentoken/notebook_helpers_test.py
+++ b/lib/python/opentoken/src/test/opentoken/notebook_helpers_test.py
@@ -1,0 +1,152 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+
+Tests for notebook helpers module.
+"""
+
+import pytest
+from opentoken.notebook_helpers import (
+    TokenBuilder,
+    CustomTokenDefinition,
+    create_token_generator,
+    quick_token,
+    list_attributes,
+    expression_help,
+    ATTRIBUTE_MAP
+)
+from opentoken.attributes.person.first_name_attribute import FirstNameAttribute
+from opentoken.attributes.person.last_name_attribute import LastNameAttribute
+from opentoken.attributes.general.record_id_attribute import RecordIdAttribute
+
+
+def test_token_builder_basic():
+    """Test basic token builder functionality."""
+    token = TokenBuilder("T6") \
+        .add("last_name", "T|U") \
+        .add("first_name", "T|U") \
+        .build()
+    
+    assert token.get_identifier() == "T6"
+    definition = token.get_definition()
+    assert len(definition) == 2
+    assert definition[0].attribute_class == LastNameAttribute
+    assert definition[1].attribute_class == FirstNameAttribute
+
+
+def test_token_builder_with_class():
+    """Test token builder with attribute class instead of string."""
+    token = TokenBuilder("T7") \
+        .add(FirstNameAttribute, "T|U") \
+        .add(LastNameAttribute, "T|S(0,3)|U") \
+        .build()
+    
+    assert token.get_identifier() == "T7"
+    definition = token.get_definition()
+    assert len(definition) == 2
+
+
+def test_token_builder_invalid_attribute():
+    """Test that invalid attribute name raises error."""
+    with pytest.raises(ValueError, match="Unknown attribute"):
+        TokenBuilder("T8").add("invalid_attr", "T|U")
+
+
+def test_custom_token_definition():
+    """Test custom token definition."""
+    token1 = TokenBuilder("T6").add("last_name", "T|U").build()
+    token2 = TokenBuilder("T7").add("first_name", "T|U").build()
+    
+    definition = CustomTokenDefinition()
+    definition.add_token(token1)
+    definition.add_token(token2)
+    
+    assert definition.get_version() == "2.0-custom"
+    assert definition.get_token_identifiers() == {"T6", "T7"}
+    assert definition.get_token_definition("T6") is not None
+    assert definition.get_token_definition("T7") is not None
+    assert definition.get_token_definition("T99") is None
+
+
+def test_create_token_generator():
+    """Test token generator creation."""
+    generator = create_token_generator(
+        "test-hash-secret",
+        "12345678901234567890123456789012"  # Exactly 32 characters
+    )
+    
+    assert generator is not None
+
+
+def test_create_token_generator_with_custom_definition():
+    """Test token generator with custom definition."""
+    token = TokenBuilder("T6").add("last_name", "T|U").build()
+    definition = CustomTokenDefinition().add_token(token)
+    
+    generator = create_token_generator(
+        "test-hash-secret",
+        "12345678901234567890123456789012",  # Exactly 32 characters
+        definition
+    )
+    
+    assert generator is not None
+
+
+def test_quick_token():
+    """Test quick token creation."""
+    generator = quick_token(
+        "T6",
+        [
+            ("last_name", "T|U"),
+            ("first_name", "T|U"),
+            ("birth_date", "T|D")
+        ],
+        "test-hash-secret",
+        "12345678901234567890123456789012"  # Exactly 32 characters
+    )
+    
+    assert generator is not None
+
+
+def test_quick_token_generates_tokens():
+    """Test that quick token actually generates tokens."""
+    generator = quick_token(
+        "T6",
+        [
+            ("last_name", "T|U"),
+            ("first_name", "T|U"),
+        ],
+        "test-hash-secret",
+        "12345678901234567890123456789012"  # Exactly 32 characters
+    )
+    
+    person_attrs = {
+        RecordIdAttribute: "1",
+        FirstNameAttribute: "John",
+        LastNameAttribute: "Doe",
+    }
+    
+    result = generator.get_all_tokens(person_attrs)
+    assert "T6" in result.tokens
+    assert result.tokens["T6"] is not None
+
+
+def test_list_attributes():
+    """Test listing available attributes."""
+    attrs = list_attributes()
+    
+    assert "first_name" in attrs
+    assert "last_name" in attrs
+    assert "birth_date" in attrs
+    assert attrs["first_name"] == FirstNameAttribute
+    assert attrs["last_name"] == LastNameAttribute
+
+
+def test_expression_help():
+    """Test expression help text."""
+    help_text = expression_help()
+    
+    assert "T" in help_text
+    assert "U" in help_text
+    assert "S(start,end)" in help_text
+    assert "D" in help_text
+    assert "Examples:" in help_text


### PR DESCRIPTION
This PR introduces the `opentoken-pyspark` bridge library to compute OpenToken tokens from PySpark DataFrames.

Highlights:
- New package at `lib/python/opentoken-pyspark` with packaging, examples, and notebooks
- Simple API to pass secrets and return tokenized DataFrames

Fixes #38